### PR TITLE
chore: fix foundry.toml and .env.example, add Amoy RPC URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,7 @@ RPC_ZKEVM=https://zkevm-rpc.com
 RPC_GNOSIS=https://rpc.ankr.com/gnosis
 RPC_BNB=https://binance.llamarpc.com
 RPC_SCROLL=https://rpc.scroll.io
+RPC_AMOY="https://rpc-amoy.polygon.technology"
 
 # Etherscan api keys for verification & download utils
 ETHERSCAN_API_KEY_MAINNET=
@@ -35,6 +36,7 @@ ETHERSCAN_API_KEY_ZKEVM=
 ETHERSCAN_API_KEY_GNOSIS=
 ETHERSCAN_API_KEY_BNB=
 ETHERSCAN_API_KEY_SCROLL=
+ETHERSCAN_API_KEY_CELO=
 
 # Simulation/fork creation
 TENDERLY_ACCESS_TOKEN=

--- a/foundry.toml
+++ b/foundry.toml
@@ -31,6 +31,7 @@ fantom_testnet = "${RPC_FANTOM_TESTNET}"
 harmony = "${RPC_HARMONY}"
 sepolia = "${RPC_SEPOLIA}"
 mumbai = "${RPC_MUMBAI}"
+amoy = "${RPC_AMOY}"
 bnb_testnet = "${RPC_BNB_TESTNET}"
 bnb = "${RPC_BNB}"
 gnosis = "${RPC_GNOSIS}"
@@ -45,8 +46,9 @@ arbitrum={key="${ETHERSCAN_API_KEY_ARBITRUM}",chainId=42161}
 fantom={key="${ETHERSCAN_API_KEY_FANTOM}",chainId=250}
 scroll={key="${ETHERSCAN_API_KEY_SCROLL}",chainId=534352, url='https://api.scrollscan.com/api\?'}
 celo={key="${ETHERSCAN_API_KEY_CELO}",chainId=42220}
-sepolia={key="${ETHERSCAN_API_KEY_SEPOLIA}",chainId=11155111}
-mumbai={key="${ETHERSCAN_API_KEY_MUMBAI}",chainId=11155111}
+sepolia={key="${ETHERSCAN_API_KEY_MAINNET}",chainId=11155111}
+mumbai={key="${ETHERSCAN_API_KEY_POLYGON}",chainId=80001}
+amoy={key="${ETHERSCAN_API_KEY_POLYGON}",chainId=80002}
 bnb_testnet={key="${ETHERSCAN_API_KEY_BNB}",chainId=97,url='https://api-testnet.bscscan.com/api'}
 bnb={key="${ETHERSCAN_API_KEY_BNB}",chainId=56,url='https://api.bscscan.com/api'}
 base={key="${ETHERSCAN_API_KEY_BASE}",chain=8453}


### PR DESCRIPTION
### Rationale

Repository must be able to work by default by copying .env.example, but due Celo environment key is missing, `forge script` throws an error.

Added Polygon Amoy RPC URL, due Polygon Mumbai is now a deprecated network.

### Changes
- Fix chain ids at foundry.toml
- Add Celo environment variable at .env.example
- Add Polygon Amoy testnet to foundry.toml and .env.example
