### PR TITLE
feat: expose latest answer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,4 +35,5 @@ coverage :; forge coverage --report lcov && \
 download :; cast etherscan-source --chain ${chain} -d src/etherscan/${chain}_${address} ${address}
 git-diff :
 	@mkdir -p diffs
+	@npx prettier ${before} ${after} --write
 	@printf '%s\n%s\n%s\n' "\`\`\`diff" "$$(git diff --no-index --diff-algorithm=patience --ignore-space-at-eol ${before} ${after})" "\`\`\`" > diffs/${out}.md

--- a/src/periphery/contracts/static-a-token/README.md
+++ b/src/periphery/contracts/static-a-token/README.md
@@ -43,3 +43,12 @@ For this project, the security procedures applied/being finished are:
 - The static A tokens are given a `rescuable`, which can be used by the ACL admin to rescue tokens locked to the contract.
 - Permit params have been excluded from the METADEPOSIT_TYPEHASH as they are not necessary. Even if someone were to frontrun the permit via mempool observation the permit is wrapped in a `try..catch` to prevent griefing attacks.
 - The static a token not implements pausability, which allows the ACL admin to pause all transfers.
+
+The storage layout diff was generated via:
+```
+git checkout main
+forge inspect src/periphery/contracts/static-a-token/StaticATokenLM.sol:StaticATokenLM storage-layout --pretty > reports/StaticATokenStorageBefore.md
+git checkout project-a
+forge inspect src/periphery/contracts/static-a-token/StaticATokenLM.sol:StaticATokenLM storage-layout --pretty > reports/StaticATokenStorageAfter.md
+make git-diff before=reports/StaticATokenStorageBefore.md after=reports/StaticATokenStorageAfter.md out=StaticATokenStorageDiff
+```

--- a/src/periphery/contracts/static-a-token/README.md
+++ b/src/periphery/contracts/static-a-token/README.md
@@ -36,3 +36,10 @@ For this project, the security procedures applied/being finished are:
 
 - The test suite of the codebase itself.
 - Certora audit/property checking for all the dynamics of the `stataToken`, including respecting all the specs of [EIP-4626](https://eips.ethereum.org/EIPS/eip-4626).
+
+## Upgrade Notes Umbrella
+
+- Interface inheritance has been changed so that `IStaticATokenLM` implements `IERC4626`, making it easier for integrators to work with the interface.
+- The static A tokens are given a `rescuable`, which can be used by the ACL admin to rescue tokens locked to the contract.
+- Permit params have been excluded from the METADEPOSIT_TYPEHASH as they are not necessary. Even if someone were to frontrun the permit via mempool observation the permit is wrapped in a `try..catch` to prevent griefing attacks.
+- The static a token not implements pausability, which allows the ACL admin to pause all transfers.

--- a/src/periphery/contracts/static-a-token/StaticATokenLM.sol
+++ b/src/periphery/contracts/static-a-token/StaticATokenLM.sol
@@ -443,14 +443,6 @@ contract StaticATokenLM is
     return assets;
   }
 
-  function latestAnswer() external view returns (int256) {
-    return
-      int256(
-        (IAaveOracle(POOL_ADDRESSES_PROVIDER.getPriceOracle()).getAssetPrice(_aTokenUnderlying) *
-          POOL.getReserveNormalizedIncome(_aTokenUnderlying)) / 1e27
-      );
-  }
-
   ///@inheritdoc IStaticATokenLM
   function redeem(
     uint256 shares,
@@ -459,6 +451,15 @@ contract StaticATokenLM is
     bool withdrawFromAave
   ) external virtual returns (uint256, uint256) {
     return _withdraw(owner, receiver, shares, 0, withdrawFromAave);
+  }
+
+  ///@inheritdoc IStaticATokenLM
+  function latestAnswer() external view returns (int256) {
+    return
+      int256(
+        (IAaveOracle(POOL_ADDRESSES_PROVIDER.getPriceOracle()).getAssetPrice(_aTokenUnderlying) *
+          POOL.getReserveNormalizedIncome(_aTokenUnderlying)) / 1e27
+      );
   }
 
   function _deposit(

--- a/src/periphery/contracts/static-a-token/StaticATokenLM.sol
+++ b/src/periphery/contracts/static-a-token/StaticATokenLM.sol
@@ -94,7 +94,7 @@ contract StaticATokenLM is
 
   /// @inheritdoc IRescuable
   function whoCanRescue() public view override returns (address) {
-    return POOL.ADDRESSES_PROVIDER().getACLAdmin();
+    return POOL_ADDRESSES_PROVIDER.getACLAdmin();
   }
 
   ///@inheritdoc IStaticATokenLM

--- a/src/periphery/contracts/static-a-token/interfaces/IStaticATokenLM.sol
+++ b/src/periphery/contracts/static-a-token/interfaces/IStaticATokenLM.sol
@@ -210,4 +210,10 @@ interface IStaticATokenLM is IInitializableStaticATokenLM, IERC4626 {
    * @return bool signaling if token is a registered reward.
    */
   function isRegisteredRewardToken(address reward) external view returns (bool);
+
+  /**
+   * @notice Returns the current asset price of the stataToken, priced by aave-oracle * exchangeRate.
+   * @return int256 the current asset price in 8 decimals.
+   */
+  function latestAnswer() external view returns (int256);
 }

--- a/tests/periphery/static-a-token/StaticATokenLM.t.sol
+++ b/tests/periphery/static-a-token/StaticATokenLM.t.sol
@@ -52,6 +52,13 @@ contract StaticATokenLMTest is BaseTest {
     );
   }
 
+  function test_latestAnswer() public view {
+    uint256 stataPrice = uint256(staticATokenLM.latestAnswer());
+    uint256 underlyingPrice = contracts.aaveOracle.getAssetPrice(UNDERLYING);
+    assertGe(stataPrice, underlyingPrice);
+    assertEq(stataPrice, (underlyingPrice * staticATokenLM.convertToAssets(1e18)) / 1e18);
+  }
+
   function test_convertersAndPreviews() public view {
     uint128 amount = 5 ether;
     uint256 shares = staticATokenLM.convertToShares(amount);


### PR DESCRIPTION
Adds `latestAnswer` as the oracle price directly on the stake-token.
This should help with dx/ux as people no longer have to query some aggregator.
It's important to not that the oracle price as composed as `price * exchangeRate` where price is the pricing based on aave-oracle (si it might include capo or similar mechanisms).