### PR TITLE
Update METADEPOSIT_TYPEHASH

### DIFF
--- a/src/periphery/contracts/static-a-token/StaticATokenLM.sol
+++ b/src/periphery/contracts/static-a-token/StaticATokenLM.sol
@@ -42,7 +42,7 @@ contract StaticATokenLM is
 
   bytes32 public constant METADEPOSIT_TYPEHASH =
     keccak256(
-      'Deposit(address depositor,address receiver,uint256 assets,uint16 referralCode,bool depositToAave,uint256 nonce,uint256 deadline,PermitParams permit)'
+      'Deposit(address depositor,address receiver,uint256 assets,uint16 referralCode,bool depositToAave,uint256 nonce,uint256 deadline)'
     );
   bytes32 public constant METAWITHDRAWAL_TYPEHASH =
     keccak256(
@@ -149,8 +149,7 @@ contract StaticATokenLM is
               referralCode,
               depositToAave,
               nonce,
-              deadline,
-              permit
+              deadline
             )
           )
         )

--- a/src/periphery/contracts/static-a-token/interfaces/IStaticATokenLM.sol
+++ b/src/periphery/contracts/static-a-token/interfaces/IStaticATokenLM.sol
@@ -13,8 +13,6 @@ interface IStaticATokenLM is IInitializableStaticATokenLM, IERC4626 {
   }
 
   struct PermitParams {
-    address owner;
-    address spender;
     uint256 value;
     uint256 deadline;
     uint8 v;

--- a/tests/periphery/static-a-token/StaticATokenMetaTransactions.t.sol
+++ b/tests/periphery/static-a-token/StaticATokenMetaTransactions.t.sol
@@ -50,8 +50,7 @@ contract StaticATokenMetaTransactions is BaseTest {
       referralCode: 0,
       fromUnderlying: true,
       nonce: staticATokenLM.nonces(user),
-      deadline: block.timestamp + 1 days,
-      permit: permitParams
+      deadline: block.timestamp + 1 days
     });
     bytes32 digest = SigUtils.getTypedDepositHash(
       metaDepositParams,
@@ -114,8 +113,7 @@ contract StaticATokenMetaTransactions is BaseTest {
       referralCode: 0,
       fromUnderlying: true,
       nonce: staticATokenLM.nonces(user),
-      deadline: permit.deadline,
-      permit: permitParams
+      deadline: permit.deadline
     });
     (uint8 v, bytes32 r, bytes32 s) = vm.sign(
       userPrivateKey,
@@ -181,8 +179,7 @@ contract StaticATokenMetaTransactions is BaseTest {
       referralCode: 0,
       fromUnderlying: false,
       nonce: staticATokenLM.nonces(user),
-      deadline: permit.deadline,
-      permit: permitParams
+      deadline: permit.deadline
     });
     bytes32 digest = SigUtils.getTypedDepositHash(
       metaDepositParams,

--- a/tests/periphery/static-a-token/StaticATokenMetaTransactions.t.sol
+++ b/tests/periphery/static-a-token/StaticATokenMetaTransactions.t.sol
@@ -43,10 +43,10 @@ contract StaticATokenMetaTransactions is BaseTest {
     IStaticATokenLM.PermitParams memory permitParams;
 
     // generate combined permit
-    SigUtils.DepositPermit memory depositPermit = SigUtils.DepositPermit({
-      owner: user,
-      spender: spender,
-      value: 1e6,
+    SigUtils.MetaDepositParams memory metaDepositParams = SigUtils.MetaDepositParams({
+      depositor: user,
+      receiver: spender,
+      assets: 1e6,
       referralCode: 0,
       fromUnderlying: true,
       nonce: staticATokenLM.nonces(user),
@@ -54,7 +54,7 @@ contract StaticATokenMetaTransactions is BaseTest {
       permit: permitParams
     });
     bytes32 digest = SigUtils.getTypedDepositHash(
-      depositPermit,
+      metaDepositParams,
       staticATokenLM.METADEPOSIT_TYPEHASH(),
       staticATokenLM.DOMAIN_SEPARATOR()
     );
@@ -62,19 +62,19 @@ contract StaticATokenMetaTransactions is BaseTest {
 
     IStaticATokenLM.SignatureParams memory sigParams = IStaticATokenLM.SignatureParams(v, r, s);
 
-    uint256 previewDeposit = staticATokenLM.previewDeposit(depositPermit.value);
+    uint256 previewDeposit = staticATokenLM.previewDeposit(metaDepositParams.assets);
     staticATokenLM.metaDeposit(
-      depositPermit.owner,
-      depositPermit.spender,
-      depositPermit.value,
-      depositPermit.referralCode,
-      depositPermit.fromUnderlying,
-      depositPermit.deadline,
+      metaDepositParams.depositor,
+      metaDepositParams.receiver,
+      metaDepositParams.assets,
+      metaDepositParams.referralCode,
+      metaDepositParams.fromUnderlying,
+      metaDepositParams.deadline,
       permitParams,
       sigParams
     );
 
-    assertEq(staticATokenLM.balanceOf(depositPermit.spender), previewDeposit);
+    assertEq(staticATokenLM.balanceOf(metaDepositParams.receiver), previewDeposit);
   }
 
   function test_metaDepositATokenUnderlying() public {
@@ -99,8 +99,6 @@ contract StaticATokenMetaTransactions is BaseTest {
     (uint8 pV, bytes32 pR, bytes32 pS) = vm.sign(userPrivateKey, permitDigest);
 
     IStaticATokenLM.PermitParams memory permitParams = IStaticATokenLM.PermitParams(
-      permit.owner,
-      permit.spender,
       permit.value,
       permit.deadline,
       pV,
@@ -109,10 +107,10 @@ contract StaticATokenMetaTransactions is BaseTest {
     );
 
     // generate combined permit
-    SigUtils.DepositPermit memory depositPermit = SigUtils.DepositPermit({
-      owner: user,
-      spender: spender,
-      value: permit.value,
+    SigUtils.MetaDepositParams memory metaDepositParams = SigUtils.MetaDepositParams({
+      depositor: user,
+      receiver: spender,
+      assets: permit.value,
       referralCode: 0,
       fromUnderlying: true,
       nonce: staticATokenLM.nonces(user),
@@ -122,7 +120,7 @@ contract StaticATokenMetaTransactions is BaseTest {
     (uint8 v, bytes32 r, bytes32 s) = vm.sign(
       userPrivateKey,
       SigUtils.getTypedDepositHash(
-        depositPermit,
+        metaDepositParams,
         staticATokenLM.METADEPOSIT_TYPEHASH(),
         staticATokenLM.DOMAIN_SEPARATOR()
       )
@@ -130,19 +128,19 @@ contract StaticATokenMetaTransactions is BaseTest {
 
     IStaticATokenLM.SignatureParams memory sigParams = IStaticATokenLM.SignatureParams(v, r, s);
 
-    uint256 previewDeposit = staticATokenLM.previewDeposit(depositPermit.value);
+    uint256 previewDeposit = staticATokenLM.previewDeposit(metaDepositParams.assets);
     uint256 shares = staticATokenLM.metaDeposit(
-      depositPermit.owner,
-      depositPermit.spender,
-      depositPermit.value,
-      depositPermit.referralCode,
-      depositPermit.fromUnderlying,
-      depositPermit.deadline,
+      metaDepositParams.depositor,
+      metaDepositParams.receiver,
+      metaDepositParams.assets,
+      metaDepositParams.referralCode,
+      metaDepositParams.fromUnderlying,
+      metaDepositParams.deadline,
       permitParams,
       sigParams
     );
     assertEq(shares, previewDeposit);
-    assertEq(staticATokenLM.balanceOf(depositPermit.spender), previewDeposit);
+    assertEq(staticATokenLM.balanceOf(metaDepositParams.receiver), previewDeposit);
   }
 
   function test_metaDepositAToken() public {
@@ -168,8 +166,6 @@ contract StaticATokenMetaTransactions is BaseTest {
     (uint8 pV, bytes32 pR, bytes32 pS) = vm.sign(userPrivateKey, permitDigest);
 
     IStaticATokenLM.PermitParams memory permitParams = IStaticATokenLM.PermitParams(
-      permit.owner,
-      permit.spender,
       permit.value,
       permit.deadline,
       pV,
@@ -178,10 +174,10 @@ contract StaticATokenMetaTransactions is BaseTest {
     );
 
     // generate combined permit
-    SigUtils.DepositPermit memory depositPermit = SigUtils.DepositPermit({
-      owner: user,
-      spender: spender,
-      value: permit.value,
+    SigUtils.MetaDepositParams memory metaDepositParams = SigUtils.MetaDepositParams({
+      depositor: user,
+      receiver: spender,
+      assets: permit.value,
       referralCode: 0,
       fromUnderlying: false,
       nonce: staticATokenLM.nonces(user),
@@ -189,7 +185,7 @@ contract StaticATokenMetaTransactions is BaseTest {
       permit: permitParams
     });
     bytes32 digest = SigUtils.getTypedDepositHash(
-      depositPermit,
+      metaDepositParams,
       staticATokenLM.METADEPOSIT_TYPEHASH(),
       staticATokenLM.DOMAIN_SEPARATOR()
     );
@@ -197,20 +193,20 @@ contract StaticATokenMetaTransactions is BaseTest {
 
     IStaticATokenLM.SignatureParams memory sigParams = IStaticATokenLM.SignatureParams(v, r, s);
 
-    uint256 previewDeposit = staticATokenLM.previewDeposit(depositPermit.value);
+    uint256 previewDeposit = staticATokenLM.previewDeposit(metaDepositParams.assets);
 
     staticATokenLM.metaDeposit(
-      depositPermit.owner,
-      depositPermit.spender,
-      depositPermit.value,
-      depositPermit.referralCode,
-      depositPermit.fromUnderlying,
-      depositPermit.deadline,
+      metaDepositParams.depositor,
+      metaDepositParams.receiver,
+      metaDepositParams.assets,
+      metaDepositParams.referralCode,
+      metaDepositParams.fromUnderlying,
+      metaDepositParams.deadline,
       permitParams,
       sigParams
     );
 
-    assertEq(staticATokenLM.balanceOf(depositPermit.spender), previewDeposit);
+    assertEq(staticATokenLM.balanceOf(metaDepositParams.receiver), previewDeposit);
   }
 
   function test_metaWithdraw() public {
@@ -219,7 +215,7 @@ contract StaticATokenMetaTransactions is BaseTest {
 
     _depositAToken(amountToDeposit, user);
 
-    SigUtils.WithdrawPermit memory permit = SigUtils.WithdrawPermit({
+    SigUtils.MetaWithdrawParams memory permit = SigUtils.MetaWithdrawParams({
       owner: user,
       spender: spender,
       staticAmount: 0,

--- a/tests/utils/SigUtils.sol
+++ b/tests/utils/SigUtils.sol
@@ -12,7 +12,7 @@ library SigUtils {
     uint256 deadline;
   }
 
-  struct WithdrawPermit {
+  struct MetaWithdrawParams {
     address owner;
     address spender;
     uint256 staticAmount;
@@ -22,10 +22,10 @@ library SigUtils {
     uint256 deadline;
   }
 
-  struct DepositPermit {
-    address owner;
-    address spender;
-    uint256 value;
+  struct MetaDepositParams {
+    address depositor;
+    address receiver;
+    uint256 assets;
     uint16 referralCode;
     bool fromUnderlying;
     uint256 nonce;
@@ -49,7 +49,7 @@ library SigUtils {
   }
 
   function getWithdrawHash(
-    WithdrawPermit memory permit,
+    MetaWithdrawParams memory permit,
     bytes32 typehash
   ) internal pure returns (bytes32) {
     return
@@ -68,21 +68,20 @@ library SigUtils {
   }
 
   function getDepositHash(
-    DepositPermit memory permit,
+    MetaDepositParams memory params,
     bytes32 typehash
   ) internal pure returns (bytes32) {
     return
       keccak256(
         abi.encode(
           typehash,
-          permit.owner,
-          permit.spender,
-          permit.value,
-          permit.referralCode,
-          permit.fromUnderlying,
-          permit.nonce,
-          permit.deadline,
-          permit.permit
+          params.depositor,
+          params.receiver,
+          params.assets,
+          params.referralCode,
+          params.fromUnderlying,
+          params.nonce,
+          params.deadline
         )
       );
   }
@@ -98,20 +97,20 @@ library SigUtils {
   }
 
   function getTypedWithdrawHash(
-    WithdrawPermit memory permit,
+    MetaWithdrawParams memory params,
     bytes32 typehash,
     bytes32 domainSeparator
   ) public pure returns (bytes32) {
     return
-      keccak256(abi.encodePacked('\x19\x01', domainSeparator, getWithdrawHash(permit, typehash)));
+      keccak256(abi.encodePacked('\x19\x01', domainSeparator, getWithdrawHash(params, typehash)));
   }
 
   function getTypedDepositHash(
-    DepositPermit memory permit,
+    MetaDepositParams memory params,
     bytes32 typehash,
     bytes32 domainSeparator
   ) public pure returns (bytes32) {
     return
-      keccak256(abi.encodePacked('\x19\x01', domainSeparator, getDepositHash(permit, typehash)));
+      keccak256(abi.encodePacked('\x19\x01', domainSeparator, getDepositHash(params, typehash)));
   }
 }

--- a/tests/utils/SigUtils.sol
+++ b/tests/utils/SigUtils.sol
@@ -30,7 +30,6 @@ library SigUtils {
     bool fromUnderlying;
     uint256 nonce;
     uint256 deadline;
-    IStaticATokenLM.PermitParams permit;
   }
 
   // computes the hash of a permit


### PR DESCRIPTION
After continuous internal discussion, we decided to exclude permit data from `METADEPOSIT_TYPEHASH`, because it gets validated on the third-party contract and signed by the user independently.

Also metaDeposit function has try-catch around permit execution to prevent griefing, and enforcing depositor's and stataToken data on it