### PR TITLE
feat: pausability

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -4,14 +4,17 @@ test = 'tests'
 script = 'scripts'
 optimizer = true
 optimizer_runs = 200
-solc='0.8.19'
+solc = '0.8.20'
 evm_version = 'paris'
 bytecode_hash = 'none'
 out = 'out'
 libs = ['lib']
-remappings = [
+remappings = []
+fs_permissions = [
+    { access = "write", path = "./reports" },
+    { access = "read", path = "./out" },
+    { access = "read", path = "./config" },
 ]
-fs_permissions = [{access = "write", path = "./reports"}, {access = "read", path = "./out" }, {access = "read", path = "./config"}]
 ffi = true
 
 [fuzz]
@@ -25,7 +28,7 @@ avalanche = "${RPC_AVALANCHE}"
 polygon = "${RPC_POLYGON}"
 arbitrum = "${RPC_ARBITRUM}"
 fantom = "${RPC_FANTOM}"
-scroll= "${RPC_SCROLL}"
+scroll = "${RPC_SCROLL}"
 celo = "${RPC_CELO}"
 fantom_testnet = "${RPC_FANTOM_TESTNET}"
 harmony = "${RPC_HARMONY}"
@@ -38,19 +41,19 @@ gnosis = "${RPC_GNOSIS}"
 base = "${RPC_BASE}"
 
 [etherscan]
-mainnet={key="${ETHERSCAN_API_KEY_MAINNET}",chainId=1}
-optimism={key="${ETHERSCAN_API_KEY_OPTIMISM}",chainId=10}
-avalanche={key="${ETHERSCAN_API_KEY_AVALANCHE}",chainId=43114}
-polygon={key="${ETHERSCAN_API_KEY_POLYGON}",chainId=137}
-arbitrum={key="${ETHERSCAN_API_KEY_ARBITRUM}",chainId=42161}
-fantom={key="${ETHERSCAN_API_KEY_FANTOM}",chainId=250}
-scroll={key="${ETHERSCAN_API_KEY_SCROLL}",chainId=534352, url='https://api.scrollscan.com/api\?'}
-celo={key="${ETHERSCAN_API_KEY_CELO}",chainId=42220}
-sepolia={key="${ETHERSCAN_API_KEY_MAINNET}",chainId=11155111}
-mumbai={key="${ETHERSCAN_API_KEY_POLYGON}",chainId=80001}
-amoy={key="${ETHERSCAN_API_KEY_POLYGON}",chainId=80002}
-bnb_testnet={key="${ETHERSCAN_API_KEY_BNB}",chainId=97,url='https://api-testnet.bscscan.com/api'}
-bnb={key="${ETHERSCAN_API_KEY_BNB}",chainId=56,url='https://api.bscscan.com/api'}
-base={key="${ETHERSCAN_API_KEY_BASE}",chain=8453}
-gnosis={key="${ETHERSCAN_API_KEY_GNOSIS}",chainId=100}
+mainnet = { key = "${ETHERSCAN_API_KEY_MAINNET}", chainId = 1 }
+optimism = { key = "${ETHERSCAN_API_KEY_OPTIMISM}", chainId = 10 }
+avalanche = { key = "${ETHERSCAN_API_KEY_AVALANCHE}", chainId = 43114 }
+polygon = { key = "${ETHERSCAN_API_KEY_POLYGON}", chainId = 137 }
+arbitrum = { key = "${ETHERSCAN_API_KEY_ARBITRUM}", chainId = 42161 }
+fantom = { key = "${ETHERSCAN_API_KEY_FANTOM}", chainId = 250 }
+scroll = { key = "${ETHERSCAN_API_KEY_SCROLL}", chainId = 534352, url = 'https://api.scrollscan.com/api\?' }
+celo = { key = "${ETHERSCAN_API_KEY_CELO}", chainId = 42220 }
+sepolia = { key = "${ETHERSCAN_API_KEY_MAINNET}", chainId = 11155111 }
+mumbai = { key = "${ETHERSCAN_API_KEY_POLYGON}", chainId = 80001 }
+amoy = { key = "${ETHERSCAN_API_KEY_POLYGON}", chainId = 80002 }
+bnb_testnet = { key = "${ETHERSCAN_API_KEY_BNB}", chainId = 97, url = 'https://api-testnet.bscscan.com/api' }
+bnb = { key = "${ETHERSCAN_API_KEY_BNB}", chainId = 56, url = 'https://api.bscscan.com/api' }
+base = { key = "${ETHERSCAN_API_KEY_BASE}", chain = 8453 }
+gnosis = { key = "${ETHERSCAN_API_KEY_GNOSIS}", chainId = 100 }
 # See more config options https://github.com/gakonst/foundry/tree/master/config

--- a/src/periphery/contracts/static-a-token/DeprecationGap.sol
+++ b/src/periphery/contracts/static-a-token/DeprecationGap.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.10;
+
+/**
+ * This contract adds a single slot gap
+ * The slot is required to account for the now deprecated initializable
+ */
+contract DeprecationGap {
+  uint256 internal __gap;
+}

--- a/src/periphery/contracts/static-a-token/DeprecationGap.sol
+++ b/src/periphery/contracts/static-a-token/DeprecationGap.sol
@@ -3,8 +3,10 @@ pragma solidity ^0.8.10;
 
 /**
  * This contract adds a single slot gap
- * The slot is required to account for the now deprecated initializable
+ * The slot is required to account for the now deprecated Initializable.
+ * The new version of Initializable uses erc7201, so it no longer occupies the first slot.
+ * https://github.com/OpenZeppelin/openzeppelin-contracts-upgradeable/blob/master/contracts/proxy/utils/Initializable.sol#L60
  */
 contract DeprecationGap {
-  uint256 internal __gap;
+  uint256 internal __deprecated_initializable_gap;
 }

--- a/src/periphery/contracts/static-a-token/StaticATokenFactory.sol
+++ b/src/periphery/contracts/static-a-token/StaticATokenFactory.sol
@@ -4,7 +4,6 @@ pragma solidity ^0.8.10;
 import {IPool, DataTypes} from '../../../core/contracts/interfaces/IPool.sol';
 import {IERC20Metadata} from 'solidity-utils/contracts/oz-common/interfaces/IERC20Metadata.sol';
 import {ITransparentProxyFactory} from 'solidity-utils/contracts/transparent-proxy/interfaces/ITransparentProxyFactory.sol';
-import {ProxyAdmin} from 'solidity-utils/contracts/transparent-proxy/ProxyAdmin.sol';
 import {Initializable} from 'solidity-utils/contracts/transparent-proxy/Initializable.sol';
 import {StaticATokenLM} from './StaticATokenLM.sol';
 import {IStaticATokenFactory} from './interfaces/IStaticATokenFactory.sol';

--- a/src/periphery/contracts/static-a-token/StaticATokenFactory.sol
+++ b/src/periphery/contracts/static-a-token/StaticATokenFactory.sol
@@ -64,10 +64,6 @@ contract StaticATokenFactory is Initializable, IStaticATokenFactory {
           ),
           bytes32(uint256(uint160(underlyings[i])))
         );
-        StaticATokenLM(staticAToken).initializeRev2(
-          POOL.ADDRESSES_PROVIDER().getACLAdmin(),
-          address(0) // TODO: how to find guardian?
-        );
 
         _underlyingToStaticAToken[underlyings[i]] = staticAToken;
         staticATokens[i] = staticAToken;

--- a/src/periphery/contracts/static-a-token/StaticATokenLM.sol
+++ b/src/periphery/contracts/static-a-token/StaticATokenLM.sol
@@ -94,7 +94,7 @@ contract StaticATokenLM is
     emit Initialized(newAToken, staticATokenName, staticATokenSymbol);
   }
 
-  function initializeV2(address owner, address guardian) external reinitializer(2) {
+  function initializeRev2(address owner, address guardian) external reinitializer(2) {
     __Ownable_init(owner);
     __Ownable_With_Guardian_init(guardian);
   }

--- a/src/periphery/contracts/static-a-token/StaticATokenLM.sol
+++ b/src/periphery/contracts/static-a-token/StaticATokenLM.sol
@@ -21,6 +21,9 @@ import {IInitializableStaticATokenLM} from './interfaces/IInitializableStaticATo
 import {StaticATokenErrors} from './StaticATokenErrors.sol';
 import {RayMathExplicitRounding, Rounding} from '../libraries/RayMathExplicitRounding.sol';
 import {IERC4626} from './interfaces/IERC4626.sol';
+import {UpgradableOwnableWithGuardian} from 'solidity-utils/contracts/access-control/UpgradableOwnableWithGuardian.sol';
+import {PausableUpgradeable} from 'openzeppelin-contracts-upgradeable/contracts/utils/PausableUpgradeable.sol';
+import {DeprecationGap} from './DeprecationGap.sol';
 
 /**
  * @title StaticATokenLM
@@ -30,10 +33,12 @@ import {IERC4626} from './interfaces/IERC4626.sol';
  * @author BGD labs
  */
 contract StaticATokenLM is
-  Initializable,
+  DeprecationGap,
   ERC20('STATIC__aToken_IMPL', 'STATIC__aToken_IMPL', 18),
   IStaticATokenLM,
-  Rescuable
+  Rescuable,
+  UpgradableOwnableWithGuardian,
+  PausableUpgradeable
 {
   using SafeERC20 for IERC20;
   using SafeCast for uint256;

--- a/src/periphery/contracts/static-a-token/StaticATokenLM.sol
+++ b/src/periphery/contracts/static-a-token/StaticATokenLM.sol
@@ -64,18 +64,18 @@ contract StaticATokenLM is
   mapping(address => mapping(address => UserRewardsData)) internal _userRewardsData;
 
   constructor(IPool pool, IRewardsController rewardsController) {
-      _disableInitializers();
+    _disableInitializers();
     POOL = pool;
     INCENTIVES_CONTROLLER = rewardsController;
   }
 
   modifier onlyPauseGuardian() {
-      if(!canPause(msg.sender)) revert OnlyPauseGuardian(msg.sender);
+    if (!canPause(msg.sender)) revert OnlyPauseGuardian(msg.sender);
     _;
   }
 
-  function canPause(address actor) public view returns(bool) {
-      return IACLManager(POOL.ADDRESSES_PROVIDER().getACLManager()).isEmergencyAdmin(actor);
+  function canPause(address actor) public view returns (bool) {
+    return IACLManager(POOL.ADDRESSES_PROVIDER().getACLManager()).isEmergencyAdmin(actor);
   }
 
   ///@inheritdoc IInitializableStaticATokenLM

--- a/src/periphery/contracts/static-a-token/StaticATokenLM.sol
+++ b/src/periphery/contracts/static-a-token/StaticATokenLM.sol
@@ -74,7 +74,7 @@ contract StaticATokenLM is
     _;
   }
 
-  function canPause(address actor) public returns(bool) {
+  function canPause(address actor) public view returns(bool) {
       return IACLManager(POOL.ADDRESSES_PROVIDER().getACLManager()).isEmergencyAdmin(actor);
   }
 

--- a/src/periphery/contracts/static-a-token/StaticATokenLM.sol
+++ b/src/periphery/contracts/static-a-token/StaticATokenLM.sol
@@ -2,11 +2,11 @@
 pragma solidity ^0.8.10;
 
 import {IPool} from '../../../core/contracts/interfaces/IPool.sol';
-import {IPool} from '../../../core/contracts/interfaces/IPool.sol';
 import {DataTypes, ReserveConfiguration} from '../../../core/contracts/protocol/libraries/configuration/ReserveConfiguration.sol';
-import {IRewardsController} from '../rewards/interfaces/IRewardsController.sol';
 import {WadRayMath} from '../../../core/contracts/protocol/libraries/math/WadRayMath.sol';
 import {MathUtils} from '../../../core/contracts/protocol/libraries/math/MathUtils.sol';
+import {IACLManager} from '../../../core/contracts/interfaces/IACLManager.sol';
+import {IRewardsController} from '../rewards/interfaces/IRewardsController.sol';
 import {SafeCast} from 'solidity-utils/contracts/oz-common/SafeCast.sol';
 import {SafeERC20} from 'solidity-utils/contracts/oz-common/SafeERC20.sol';
 import {IERC20Metadata} from 'solidity-utils/contracts/oz-common/interfaces/IERC20Metadata.sol';
@@ -23,7 +23,6 @@ import {RayMathExplicitRounding, Rounding} from '../libraries/RayMathExplicitRou
 import {IERC4626} from './interfaces/IERC4626.sol';
 import {PausableUpgradeable} from 'openzeppelin-contracts-upgradeable/contracts/utils/PausableUpgradeable.sol';
 import {DeprecationGap} from './DeprecationGap.sol';
-import {IACLManager} from '../../../core/contracts/interfaces/IACLManager.sol';
 
 /**
  * @title StaticATokenLM

--- a/src/periphery/contracts/static-a-token/StaticATokenLM.sol
+++ b/src/periphery/contracts/static-a-token/StaticATokenLM.sol
@@ -652,7 +652,7 @@ contract StaticATokenLM is
     address onBehalfOf,
     address receiver,
     address[] memory rewards
-  ) internal {
+  ) internal whenNotPaused {
     for (uint256 i = 0; i < rewards.length; i++) {
       if (address(rewards[i]) == address(0)) {
         continue;

--- a/src/periphery/contracts/static-a-token/interfaces/IInitializableStaticATokenLM.sol
+++ b/src/periphery/contracts/static-a-token/interfaces/IInitializableStaticATokenLM.sol
@@ -29,6 +29,4 @@ interface IInitializableStaticATokenLM {
     string calldata staticATokenName,
     string calldata staticATokenSymbol
   ) external;
-
-  function initializeRev2(address owner, address guardian) external;
 }

--- a/src/periphery/contracts/static-a-token/interfaces/IInitializableStaticATokenLM.sol
+++ b/src/periphery/contracts/static-a-token/interfaces/IInitializableStaticATokenLM.sol
@@ -29,4 +29,6 @@ interface IInitializableStaticATokenLM {
     string calldata staticATokenName,
     string calldata staticATokenSymbol
   ) external;
+
+  function initializeRev2(address owner, address guardian) external;
 }

--- a/src/periphery/contracts/static-a-token/interfaces/IStaticATokenLM.sol
+++ b/src/periphery/contracts/static-a-token/interfaces/IStaticATokenLM.sol
@@ -215,7 +215,7 @@ interface IStaticATokenLM is IInitializableStaticATokenLM, IERC4626 {
   function isRegisteredRewardToken(address reward) external view returns (bool);
 
   /**
-   * @notice Pauses the token which will forbid all transfers
+   * @notice Pauses/unpauses all system's operations
    * @param paused boolean determining if the token should be paused or unpaused
    */
   function setPaused(bool paused) external;

--- a/src/periphery/contracts/static-a-token/interfaces/IStaticATokenLM.sol
+++ b/src/periphery/contracts/static-a-token/interfaces/IStaticATokenLM.sol
@@ -207,7 +207,14 @@ interface IStaticATokenLM is IInitializableStaticATokenLM, IERC4626 {
 
   /**
    * @notice Checks if the passed token is a registered reward.
+   * @param reward The reward to claim
    * @return bool signaling if token is a registered reward.
    */
   function isRegisteredRewardToken(address reward) external view returns (bool);
+
+  /**
+   * @notice Pauses the token which will forbid all transfers
+   * @param paused boolean determining if the token should be paused or unpaused
+   */
+  function setPaused(bool paused) external;
 }

--- a/src/periphery/contracts/static-a-token/interfaces/IStaticATokenLM.sol
+++ b/src/periphery/contracts/static-a-token/interfaces/IStaticATokenLM.sol
@@ -30,6 +30,8 @@ interface IStaticATokenLM is IInitializableStaticATokenLM, IERC4626 {
     uint248 lastUpdatedIndex;
   }
 
+  error OnlyPauseGuardian(address caller);
+
   event RewardTokenRegistered(address indexed reward, uint256 startIndex);
 
   /**

--- a/tests/periphery/static-a-token/Pausable.t.sol
+++ b/tests/periphery/static-a-token/Pausable.t.sol
@@ -105,6 +105,20 @@ contract Pausable is BaseTest {
     staticATokenLM.transfer(user1, amountToDeposit);
   }
 
+  function test_claimingRewards_shouldRevert() external {
+      _configureLM();
+    uint128 amountToDeposit = 10 ether;
+    vm.startPrank(user);
+    _fundUser(amountToDeposit, user);
+    _depositAToken(amountToDeposit, user);
+    vm.stopPrank();
+
+    _setPausedAsAclAdmin(true);
+    vm.expectRevert(PausableUpgradeable.EnforcedPause.selector);
+    vm.prank(user);
+    staticATokenLM.claimRewardsToSelf(rewardTokens);
+  }
+
   function _setPausedAsAclAdmin(bool paused) internal {
     _setPaused(poolAdmin, paused);
   }

--- a/tests/periphery/static-a-token/Pausable.t.sol
+++ b/tests/periphery/static-a-token/Pausable.t.sol
@@ -20,12 +20,7 @@ contract Pausable is BaseTest {
 
   function test_setPaused_shouldRevertForInvalidCaller(address actor) external {
     vm.assume(actor != poolAdmin && actor != proxyAdmin);
-    vm.expectRevert(
-      abi.encodeWithSelector(
-        IStaticATokenLM.OnlyPauseGuardian.selector,
-        actor
-      )
-    );
+    vm.expectRevert(abi.encodeWithSelector(IStaticATokenLM.OnlyPauseGuardian.selector, actor));
     _setPaused(actor, true);
   }
 
@@ -106,7 +101,7 @@ contract Pausable is BaseTest {
   }
 
   function test_claimingRewards_shouldRevert() external {
-      _configureLM();
+    _configureLM();
     uint128 amountToDeposit = 10 ether;
     vm.startPrank(user);
     _fundUser(amountToDeposit, user);

--- a/tests/periphery/static-a-token/Pausable.t.sol
+++ b/tests/periphery/static-a-token/Pausable.t.sol
@@ -22,7 +22,7 @@ contract Pausable is BaseTest {
     vm.assume(actor != poolAdmin && actor != proxyAdmin);
     vm.expectRevert(
       abi.encodeWithSelector(
-        UpgradableOwnableWithGuardian.OnlyGuardianOrOwnerInvalidCaller.selector,
+        IStaticATokenLM.OnlyPauseGuardian.selector,
         actor
       )
     );
@@ -42,7 +42,7 @@ contract Pausable is BaseTest {
     IERC20(UNDERLYING).approve(address(staticATokenLM), amountToDeposit);
     vm.stopPrank();
 
-    _setPausedAsOwner(true);
+    _setPausedAsAclAdmin(true);
     vm.expectRevert(PausableUpgradeable.EnforcedPause.selector);
     vm.prank(user);
     staticATokenLM.deposit(amountToDeposit, user, 0, true);
@@ -56,7 +56,7 @@ contract Pausable is BaseTest {
     vm.stopPrank();
 
     uint256 sharesToMint = staticATokenLM.previewDeposit(amountToDeposit);
-    _setPausedAsOwner(true);
+    _setPausedAsAclAdmin(true);
     vm.expectRevert(PausableUpgradeable.EnforcedPause.selector);
     vm.prank(user);
     staticATokenLM.mint(sharesToMint, user);
@@ -71,7 +71,7 @@ contract Pausable is BaseTest {
 
     assertEq(staticATokenLM.maxRedeem(user), staticATokenLM.balanceOf(user));
 
-    _setPausedAsOwner(true);
+    _setPausedAsAclAdmin(true);
     uint256 maxRedeem = staticATokenLM.maxRedeem(user);
     vm.expectRevert(PausableUpgradeable.EnforcedPause.selector);
     vm.prank(user);
@@ -86,7 +86,7 @@ contract Pausable is BaseTest {
     vm.stopPrank();
 
     uint256 maxWithdraw = staticATokenLM.maxWithdraw(user);
-    _setPausedAsOwner(true);
+    _setPausedAsAclAdmin(true);
     vm.expectRevert(PausableUpgradeable.EnforcedPause.selector);
     vm.prank(user);
     staticATokenLM.withdraw(maxWithdraw, user, user);
@@ -99,13 +99,13 @@ contract Pausable is BaseTest {
     _depositAToken(amountToDeposit, user);
     vm.stopPrank();
 
-    _setPausedAsOwner(true);
+    _setPausedAsAclAdmin(true);
     vm.expectRevert(PausableUpgradeable.EnforcedPause.selector);
     vm.prank(user);
     staticATokenLM.transfer(user1, amountToDeposit);
   }
 
-  function _setPausedAsOwner(bool paused) internal {
+  function _setPausedAsAclAdmin(bool paused) internal {
     _setPaused(poolAdmin, paused);
   }
 

--- a/tests/periphery/static-a-token/Pausable.t.sol
+++ b/tests/periphery/static-a-token/Pausable.t.sol
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.10;
+
+import {UpgradableOwnableWithGuardian} from 'solidity-utils/contracts/access-control/UpgradableOwnableWithGuardian.sol';
+import {PausableUpgradeable} from 'openzeppelin-contracts-upgradeable/contracts/utils/PausableUpgradeable.sol';
+import {AToken} from '../../../src/core/contracts/protocol/tokenization/AToken.sol';
+import {DataTypes} from '../../../src/core/contracts/protocol/libraries/configuration/ReserveConfiguration.sol';
+import {IERC20, IERC20Metadata} from '../../../src/periphery/contracts/static-a-token/StaticATokenLM.sol';
+import {RayMathExplicitRounding} from '../../../src/periphery/contracts/libraries/RayMathExplicitRounding.sol';
+import {PullRewardsTransferStrategy} from '../../../src/periphery/contracts/rewards/transfer-strategies/PullRewardsTransferStrategy.sol';
+import {RewardsDataTypes} from '../../../src/periphery/contracts/rewards/libraries/RewardsDataTypes.sol';
+import {ITransferStrategyBase} from '../../../src/periphery/contracts/rewards/interfaces/ITransferStrategyBase.sol';
+import {IEACAggregatorProxy} from '../../../src/periphery/contracts/misc/interfaces/IEACAggregatorProxy.sol';
+import {IStaticATokenLM} from '../../../src/periphery/contracts/static-a-token/interfaces/IStaticATokenLM.sol';
+import {SigUtils} from '../../utils/SigUtils.sol';
+import {BaseTest, TestnetERC20} from './TestBase.sol';
+
+contract Pausable is BaseTest {
+  using RayMathExplicitRounding for uint256;
+
+  function test_setPaused_shouldRevertForInvalidCaller(address actor) external {
+    vm.assume(actor != poolAdmin && actor != proxyAdmin);
+    vm.expectRevert(
+      abi.encodeWithSelector(
+        UpgradableOwnableWithGuardian.OnlyGuardianOrOwnerInvalidCaller.selector,
+        actor
+      )
+    );
+    _setPaused(actor, true);
+  }
+
+  function test_setPaused_shouldSuceedForOwner() external {
+    assertEq(PausableUpgradeable(address(staticATokenLM)).paused(), false);
+    _setPaused(poolAdmin, true);
+    assertEq(PausableUpgradeable(address(staticATokenLM)).paused(), true);
+  }
+
+  function test_deposit_shouldRevert() external {
+    vm.startPrank(user);
+    uint128 amountToDeposit = 5 ether;
+    _fundUser(amountToDeposit, user);
+    IERC20(UNDERLYING).approve(address(staticATokenLM), amountToDeposit);
+    vm.stopPrank();
+
+    _setPausedAsOwner(true);
+    vm.expectRevert(PausableUpgradeable.EnforcedPause.selector);
+    vm.prank(user);
+    staticATokenLM.deposit(amountToDeposit, user, 0, true);
+  }
+
+  function test_mint_shouldRevert() external {
+    vm.startPrank(user);
+    uint128 amountToDeposit = 5 ether;
+    _fundUser(amountToDeposit, user);
+    IERC20(UNDERLYING).approve(address(staticATokenLM), amountToDeposit);
+    vm.stopPrank();
+
+    uint256 sharesToMint = staticATokenLM.previewDeposit(amountToDeposit);
+    _setPausedAsOwner(true);
+    vm.expectRevert(PausableUpgradeable.EnforcedPause.selector);
+    vm.prank(user);
+    staticATokenLM.mint(sharesToMint, user);
+  }
+
+  function test_redeem_shouldRevert() external {
+    uint128 amountToDeposit = 5 ether;
+    vm.startPrank(user);
+    _fundUser(amountToDeposit, user);
+    _depositAToken(amountToDeposit, user);
+    vm.stopPrank();
+
+    assertEq(staticATokenLM.maxRedeem(user), staticATokenLM.balanceOf(user));
+
+    _setPausedAsOwner(true);
+    uint256 maxRedeem = staticATokenLM.maxRedeem(user);
+    vm.expectRevert(PausableUpgradeable.EnforcedPause.selector);
+    vm.prank(user);
+    staticATokenLM.redeem(maxRedeem, user, user);
+  }
+
+  function test_withdraw_shouldRevert() external {
+    uint128 amountToDeposit = 5 ether;
+    vm.startPrank(user);
+    _fundUser(amountToDeposit, user);
+    _depositAToken(amountToDeposit, user);
+    vm.stopPrank();
+
+    uint256 maxWithdraw = staticATokenLM.maxWithdraw(user);
+    _setPausedAsOwner(true);
+    vm.expectRevert(PausableUpgradeable.EnforcedPause.selector);
+    vm.prank(user);
+    staticATokenLM.withdraw(maxWithdraw, user, user);
+  }
+
+  function test_transfer_shouldRevert() external {
+    uint128 amountToDeposit = 10 ether;
+    vm.startPrank(user);
+    _fundUser(amountToDeposit, user);
+    _depositAToken(amountToDeposit, user);
+    vm.stopPrank();
+
+    _setPausedAsOwner(true);
+    vm.expectRevert(PausableUpgradeable.EnforcedPause.selector);
+    vm.prank(user);
+    staticATokenLM.transfer(user1, amountToDeposit);
+  }
+
+  function _setPausedAsOwner(bool paused) internal {
+    _setPaused(poolAdmin, paused);
+  }
+
+  function _setPaused(address actor, bool paused) internal {
+    vm.prank(actor);
+    staticATokenLM.setPaused(paused);
+  }
+}

--- a/tests/periphery/static-a-token/StaticATokenLM.t.sol
+++ b/tests/periphery/static-a-token/StaticATokenLM.t.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.10;
 
+import {IRescuable} from 'solidity-utils/contracts/utils/Rescuable.sol';
 import {AToken} from '../../../src/core/contracts/protocol/tokenization/AToken.sol';
 import {DataTypes} from '../../../src/core/contracts/protocol/libraries/configuration/ReserveConfiguration.sol';
 import {IERC20, IERC20Metadata} from '../../../src/periphery/contracts/static-a-token/StaticATokenLM.sol';
@@ -554,6 +555,26 @@ contract StaticATokenLMTest is BaseTest {
 
     vm.expectRevert('INVALID_SIGNER');
     staticATokenLM.permit(permit.owner, permit.spender, permit.value, permit.deadline, v, r, s);
+  }
+
+  function test_rescuable_shouldRevertForInvalidCaller() external {
+    deal(tokenList.usdx, address(staticATokenLM), 1 ether);
+    vm.expectRevert('ONLY_RESCUE_GUARDIAN');
+    IRescuable(address(staticATokenLM)).emergencyTokenTransfer(
+      tokenList.usdx,
+      address(this),
+      1 ether
+    );
+  }
+
+  function test_rescuable_shouldSuceedForOwner() external {
+    deal(tokenList.usdx, address(staticATokenLM), 1 ether);
+    vm.startPrank(poolAdmin);
+    IRescuable(address(staticATokenLM)).emergencyTokenTransfer(
+      tokenList.usdx,
+      address(this),
+      1 ether
+    );
   }
 
   function _configureLM() internal {

--- a/tests/periphery/static-a-token/StaticATokenLM.t.sol
+++ b/tests/periphery/static-a-token/StaticATokenLM.t.sol
@@ -7,18 +7,12 @@ import {AToken} from '../../../src/core/contracts/protocol/tokenization/AToken.s
 import {DataTypes} from '../../../src/core/contracts/protocol/libraries/configuration/ReserveConfiguration.sol';
 import {IERC20, IERC20Metadata} from '../../../src/periphery/contracts/static-a-token/StaticATokenLM.sol';
 import {RayMathExplicitRounding} from '../../../src/periphery/contracts/libraries/RayMathExplicitRounding.sol';
-import {PullRewardsTransferStrategy} from '../../../src/periphery/contracts/rewards/transfer-strategies/PullRewardsTransferStrategy.sol';
-import {RewardsDataTypes} from '../../../src/periphery/contracts/rewards/libraries/RewardsDataTypes.sol';
-import {ITransferStrategyBase} from '../../../src/periphery/contracts/rewards/interfaces/ITransferStrategyBase.sol';
-import {IEACAggregatorProxy} from '../../../src/periphery/contracts/misc/interfaces/IEACAggregatorProxy.sol';
 import {IStaticATokenLM} from '../../../src/periphery/contracts/static-a-token/interfaces/IStaticATokenLM.sol';
 import {SigUtils} from '../../utils/SigUtils.sol';
 import {BaseTest, TestnetERC20} from './TestBase.sol';
 
 contract StaticATokenLMTest is BaseTest {
   using RayMathExplicitRounding for uint256;
-
-  address public constant EMISSION_ADMIN = address(25);
 
   function setUp() public override {
     super.setUp();
@@ -578,43 +572,6 @@ contract StaticATokenLMTest is BaseTest {
     );
   }
 
-  function _configureLM() internal {
-    PullRewardsTransferStrategy strat = new PullRewardsTransferStrategy(
-      report.rewardsControllerProxy,
-      EMISSION_ADMIN,
-      EMISSION_ADMIN
-    );
-
-    vm.startPrank(poolAdmin);
-    contracts.emissionManager.setEmissionAdmin(REWARD_TOKEN, EMISSION_ADMIN);
-    vm.stopPrank();
-
-    vm.startPrank(EMISSION_ADMIN);
-    IERC20(REWARD_TOKEN).approve(address(strat), 10_000 ether);
-    vm.stopPrank();
-
-    vm.startPrank(OWNER);
-    TestnetERC20(REWARD_TOKEN).mint(EMISSION_ADMIN, 10_000 ether);
-    vm.stopPrank();
-
-    RewardsDataTypes.RewardsConfigInput[] memory config = new RewardsDataTypes.RewardsConfigInput[](
-      1
-    );
-    config[0] = RewardsDataTypes.RewardsConfigInput(
-      0.00385 ether,
-      10_000 ether,
-      uint32(block.timestamp + 30 days),
-      A_TOKEN,
-      REWARD_TOKEN,
-      ITransferStrategyBase(strat),
-      IEACAggregatorProxy(address(2))
-    );
-
-    vm.prank(EMISSION_ADMIN);
-    contracts.emissionManager.configureAssets(config);
-
-    staticATokenLM.refreshRewardTokens();
-  }
 
   function _openSupplyAndBorrowPositions() internal {
     // this is to open borrow positions so that the aToken balance increases

--- a/tests/periphery/static-a-token/StaticATokenLM.t.sol
+++ b/tests/periphery/static-a-token/StaticATokenLM.t.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.10;
 
 import {IRescuable} from 'solidity-utils/contracts/utils/Rescuable.sol';
+import {Initializable} from 'openzeppelin-contracts-upgradeable/contracts/proxy/utils/Initializable.sol';
 import {AToken} from '../../../src/core/contracts/protocol/tokenization/AToken.sol';
 import {DataTypes} from '../../../src/core/contracts/protocol/libraries/configuration/ReserveConfiguration.sol';
 import {IERC20, IERC20Metadata} from '../../../src/periphery/contracts/static-a-token/StaticATokenLM.sol';
@@ -30,8 +31,8 @@ contract StaticATokenLMTest is BaseTest {
 
   function test_initializeShouldRevert() public {
     address impl = factory.STATIC_A_TOKEN_IMPL();
-    vm.expectRevert();
-    IStaticATokenLM(impl).initialize(0xe50fA9b3c56FfB159cB0FCA61F5c9D750e8128c8, 'hey', 'ho');
+    vm.expectRevert(Initializable.InvalidInitialization.selector);
+    IStaticATokenLM(impl).initialize(A_TOKEN, 'hey', 'ho');
   }
 
   function test_getters() public view {

--- a/tests/periphery/static-a-token/StaticATokenLM.t.sol
+++ b/tests/periphery/static-a-token/StaticATokenLM.t.sol
@@ -572,7 +572,6 @@ contract StaticATokenLMTest is BaseTest {
     );
   }
 
-
   function _openSupplyAndBorrowPositions() internal {
     // this is to open borrow positions so that the aToken balance increases
     address whale = address(79);

--- a/tests/periphery/static-a-token/TestBase.sol
+++ b/tests/periphery/static-a-token/TestBase.sol
@@ -66,44 +66,43 @@ abstract contract BaseTest is TestnetProcedures {
     staticATokenLM = StaticATokenLM(factory.getStaticAToken(UNDERLYING));
   }
 
-
   function _configureLM() internal {
-      PullRewardsTransferStrategy strat = new PullRewardsTransferStrategy(
-        report.rewardsControllerProxy,
-        EMISSION_ADMIN,
-        EMISSION_ADMIN
-      );
+    PullRewardsTransferStrategy strat = new PullRewardsTransferStrategy(
+      report.rewardsControllerProxy,
+      EMISSION_ADMIN,
+      EMISSION_ADMIN
+    );
 
-      vm.startPrank(poolAdmin);
-      contracts.emissionManager.setEmissionAdmin(REWARD_TOKEN, EMISSION_ADMIN);
-      vm.stopPrank();
+    vm.startPrank(poolAdmin);
+    contracts.emissionManager.setEmissionAdmin(REWARD_TOKEN, EMISSION_ADMIN);
+    vm.stopPrank();
 
-      vm.startPrank(EMISSION_ADMIN);
-      IERC20(REWARD_TOKEN).approve(address(strat), 10_000 ether);
-      vm.stopPrank();
+    vm.startPrank(EMISSION_ADMIN);
+    IERC20(REWARD_TOKEN).approve(address(strat), 10_000 ether);
+    vm.stopPrank();
 
-      vm.startPrank(OWNER);
-      TestnetERC20(REWARD_TOKEN).mint(EMISSION_ADMIN, 10_000 ether);
-      vm.stopPrank();
+    vm.startPrank(OWNER);
+    TestnetERC20(REWARD_TOKEN).mint(EMISSION_ADMIN, 10_000 ether);
+    vm.stopPrank();
 
-      RewardsDataTypes.RewardsConfigInput[] memory config = new RewardsDataTypes.RewardsConfigInput[](
-        1
-      );
-      config[0] = RewardsDataTypes.RewardsConfigInput(
-        0.00385 ether,
-        10_000 ether,
-        uint32(block.timestamp + 30 days),
-        A_TOKEN,
-        REWARD_TOKEN,
-        ITransferStrategyBase(strat),
-        IEACAggregatorProxy(address(2))
-      );
+    RewardsDataTypes.RewardsConfigInput[] memory config = new RewardsDataTypes.RewardsConfigInput[](
+      1
+    );
+    config[0] = RewardsDataTypes.RewardsConfigInput(
+      0.00385 ether,
+      10_000 ether,
+      uint32(block.timestamp + 30 days),
+      A_TOKEN,
+      REWARD_TOKEN,
+      ITransferStrategyBase(strat),
+      IEACAggregatorProxy(address(2))
+    );
 
-      vm.prank(EMISSION_ADMIN);
-      contracts.emissionManager.configureAssets(config);
+    vm.prank(EMISSION_ADMIN);
+    contracts.emissionManager.configureAssets(config);
 
-      staticATokenLM.refreshRewardTokens();
-    }
+    staticATokenLM.refreshRewardTokens();
+  }
 
   function _fundUser(uint128 amountToDeposit, address targetUser) internal {
     deal(UNDERLYING, targetUser, amountToDeposit);

--- a/tests/periphery/static-a-token/TestBase.sol
+++ b/tests/periphery/static-a-token/TestBase.sol
@@ -2,6 +2,10 @@
 pragma solidity ^0.8.10;
 
 import {IRewardsController} from '../../../src/periphery/contracts/rewards/interfaces/IRewardsController.sol';
+import {RewardsDataTypes} from '../../../src/periphery/contracts/rewards/libraries/RewardsDataTypes.sol';
+import {PullRewardsTransferStrategy} from '../../../src/periphery/contracts/rewards/transfer-strategies/PullRewardsTransferStrategy.sol';
+import {ITransferStrategyBase} from '../../../src/periphery/contracts/rewards/interfaces/ITransferStrategyBase.sol';
+import {IEACAggregatorProxy} from '../../../src/periphery/contracts/misc/interfaces/IEACAggregatorProxy.sol';
 import {TransparentUpgradeableProxy} from 'solidity-utils/contracts/transparent-proxy/TransparentUpgradeableProxy.sol';
 import {ITransparentProxyFactory} from 'solidity-utils/contracts/transparent-proxy/TransparentProxyFactory.sol';
 import {IPool} from '../../../src/core/contracts/interfaces/IPool.sol';
@@ -13,6 +17,7 @@ import {DataTypes} from '../../../src/core/contracts/protocol/libraries/configur
 
 abstract contract BaseTest is TestnetProcedures {
   address constant OWNER = address(1234);
+  address public constant EMISSION_ADMIN = address(25);
 
   address public user;
   address public user1;
@@ -60,6 +65,45 @@ abstract contract BaseTest is TestnetProcedures {
 
     staticATokenLM = StaticATokenLM(factory.getStaticAToken(UNDERLYING));
   }
+
+
+  function _configureLM() internal {
+      PullRewardsTransferStrategy strat = new PullRewardsTransferStrategy(
+        report.rewardsControllerProxy,
+        EMISSION_ADMIN,
+        EMISSION_ADMIN
+      );
+
+      vm.startPrank(poolAdmin);
+      contracts.emissionManager.setEmissionAdmin(REWARD_TOKEN, EMISSION_ADMIN);
+      vm.stopPrank();
+
+      vm.startPrank(EMISSION_ADMIN);
+      IERC20(REWARD_TOKEN).approve(address(strat), 10_000 ether);
+      vm.stopPrank();
+
+      vm.startPrank(OWNER);
+      TestnetERC20(REWARD_TOKEN).mint(EMISSION_ADMIN, 10_000 ether);
+      vm.stopPrank();
+
+      RewardsDataTypes.RewardsConfigInput[] memory config = new RewardsDataTypes.RewardsConfigInput[](
+        1
+      );
+      config[0] = RewardsDataTypes.RewardsConfigInput(
+        0.00385 ether,
+        10_000 ether,
+        uint32(block.timestamp + 30 days),
+        A_TOKEN,
+        REWARD_TOKEN,
+        ITransferStrategyBase(strat),
+        IEACAggregatorProxy(address(2))
+      );
+
+      vm.prank(EMISSION_ADMIN);
+      contracts.emissionManager.configureAssets(config);
+
+      staticATokenLM.refreshRewardTokens();
+    }
 
   function _fundUser(uint128 amountToDeposit, address targetUser) internal {
     deal(UNDERLYING, targetUser, amountToDeposit);


### PR DESCRIPTION
This branch implements pausability by allowing any address with emergencyAdmin to pause and unpause the stata.
A pause will block any interaction with the token (depositing/redeeming/claiming rewards).

The chosen implementation uses the POOL ACL_MANAGER to check if the caller is the pause admin and reverts if otherwise.
This implementation uses the UpgreadablePausable from openzeppelin and therefore replaces the current Initializable, with the UpgreadableInitializable. The Upgreadable contracts use eip-7201 for storage which replaces sequential slot based storage for these contracts. To account for that a new 1 slot wide gap is introduced at the beginning of the inheritance chain to account for the legacy storage of Initializable.

oz-upgraedable relies on solc 8.20 features forcing us to upgrade this repo as well.