### PR TITLE
fix: Transfer excess back and reset allowance

### DIFF
--- a/src/periphery/contracts/adapters/paraswap/BaseParaSwapBuyAdapter.sol
+++ b/src/periphery/contracts/adapters/paraswap/BaseParaSwapBuyAdapter.sol
@@ -39,6 +39,7 @@ abstract contract BaseParaSwapBuyAdapter is BaseParaSwapAdapter {
    * @param maxAmountToSwap Max amount to be swapped
    * @param amountToReceive Amount to be received from the swap
    * @return amountSold The amount sold during the swap
+   * @return amountBought The amount bought during the swap
    */
   function _buyOnParaSwap(
     uint256 toAmountOffset,
@@ -47,7 +48,7 @@ abstract contract BaseParaSwapBuyAdapter is BaseParaSwapAdapter {
     IERC20Detailed assetToSwapTo,
     uint256 maxAmountToSwap,
     uint256 amountToReceive
-  ) internal returns (uint256 amountSold) {
+  ) internal returns (uint256 amountSold, uint256 amountBought) {
     (bytes memory buyCalldata, IParaSwapAugustus augustus) = abi.decode(
       paraswapData,
       (bytes, IParaSwapAugustus)
@@ -101,12 +102,15 @@ abstract contract BaseParaSwapBuyAdapter is BaseParaSwapAdapter {
       }
     }
 
+    // Reset allowance
+    assetToSwapFrom.safeApprove(tokenTransferProxy, 0);
+
     uint256 balanceAfterAssetFrom = assetToSwapFrom.balanceOf(address(this));
     amountSold = balanceBeforeAssetFrom - balanceAfterAssetFrom;
     require(amountSold <= maxAmountToSwap, 'WRONG_BALANCE_AFTER_SWAP');
-    uint256 amountReceived = assetToSwapTo.balanceOf(address(this)).sub(balanceBeforeAssetTo);
-    require(amountReceived >= amountToReceive, 'INSUFFICIENT_AMOUNT_RECEIVED');
+    amountBought = assetToSwapTo.balanceOf(address(this)).sub(balanceBeforeAssetTo);
+    require(amountBought >= amountToReceive, 'INSUFFICIENT_AMOUNT_RECEIVED');
 
-    emit Bought(address(assetToSwapFrom), address(assetToSwapTo), amountSold, amountReceived);
+    emit Bought(address(assetToSwapFrom), address(assetToSwapTo), amountSold, amountBought);
   }
 }

--- a/src/periphery/contracts/adapters/paraswap/BaseParaSwapBuyAdapter.sol
+++ b/src/periphery/contracts/adapters/paraswap/BaseParaSwapBuyAdapter.sol
@@ -76,7 +76,6 @@ abstract contract BaseParaSwapBuyAdapter is BaseParaSwapAdapter {
     uint256 balanceBeforeAssetTo = assetToSwapTo.balanceOf(address(this));
 
     address tokenTransferProxy = augustus.getTokenTransferProxy();
-    assetToSwapFrom.safeApprove(tokenTransferProxy, 0);
     assetToSwapFrom.safeApprove(tokenTransferProxy, maxAmountToSwap);
 
     if (toAmountOffset != 0) {

--- a/src/periphery/contracts/adapters/paraswap/BaseParaSwapSellAdapter.sol
+++ b/src/periphery/contracts/adapters/paraswap/BaseParaSwapSellAdapter.sol
@@ -98,6 +98,10 @@ abstract contract BaseParaSwapSellAdapter is BaseParaSwapAdapter {
         revert(0, returndatasize())
       }
     }
+    
+    // Reset allowance
+    assetToSwapFrom.safeApprove(tokenTransferProxy, 0);
+
     require(
       assetToSwapFrom.balanceOf(address(this)) == balanceBeforeAssetFrom - amountToSwap,
       'WRONG_BALANCE_AFTER_SWAP'

--- a/src/periphery/contracts/adapters/paraswap/BaseParaSwapSellAdapter.sol
+++ b/src/periphery/contracts/adapters/paraswap/BaseParaSwapSellAdapter.sol
@@ -98,9 +98,6 @@ abstract contract BaseParaSwapSellAdapter is BaseParaSwapAdapter {
         revert(0, returndatasize())
       }
     }
-    
-    // Reset allowance
-    assetToSwapFrom.safeApprove(tokenTransferProxy, 0);
 
     require(
       assetToSwapFrom.balanceOf(address(this)) == balanceBeforeAssetFrom - amountToSwap,

--- a/src/periphery/contracts/adapters/paraswap/ParaSwapRepayAdapter.sol
+++ b/src/periphery/contracts/adapters/paraswap/ParaSwapRepayAdapter.sol
@@ -139,9 +139,9 @@ contract ParaSwapRepayAdapter is BaseParaSwapBuyAdapter, ReentrancyGuard {
 
     {
       //transfer excess of debtAsset back to the user, if any
-      uint256 debtBalanceLeft = amountBought - debtRepayAmount;
-      if (debtBalanceLeft > 0) {
-        IERC20(debtAsset).safeTransfer(msg.sender, debtBalanceLeft);
+      uint256 debtAssetExcess = amountBought - debtRepayAmount;
+      if (debtAssetExcess > 0) {
+        IERC20(debtAsset).safeTransfer(msg.sender, debtAssetExcess);
       }
     }
   }
@@ -204,9 +204,9 @@ contract ParaSwapRepayAdapter is BaseParaSwapBuyAdapter, ReentrancyGuard {
 
     {
       //transfer excess of debtAsset back to the user, if any
-      uint256 debtBalanceLeft = amountBought - debtRepayAmount;
-      if (debtBalanceLeft > 0) {
-        IERC20(debtAsset).safeTransfer(initiator, debtBalanceLeft);
+      uint256 debtAssetExcess = amountBought - debtRepayAmount;
+      if (debtAssetExcess > 0) {
+        IERC20(debtAsset).safeTransfer(initiator, debtAssetExcess);
       }
     }
 

--- a/src/periphery/contracts/adapters/paraswap/ParaSwapRepayAdapter.sol
+++ b/src/periphery/contracts/adapters/paraswap/ParaSwapRepayAdapter.sol
@@ -127,15 +127,15 @@ contract ParaSwapRepayAdapter is BaseParaSwapBuyAdapter, ReentrancyGuard {
 
     //deposit collateral back in the pool, if left after the swap(buy)
     if (collateralBalanceLeft > 0) {
-      IERC20(collateralAsset).safeApprove(address(POOL), 0);
       IERC20(collateralAsset).safeApprove(address(POOL), collateralBalanceLeft);
       POOL.deposit(address(collateralAsset), collateralBalanceLeft, msg.sender, 0);
+      IERC20(collateralAsset).safeApprove(address(POOL), 0);
     }
 
     // Repay debt. Approves 0 first to comply with tokens that implement the anti frontrunning approval fix
-    IERC20(debtAsset).safeApprove(address(POOL), 0);
     IERC20(debtAsset).safeApprove(address(POOL), debtRepayAmount);
     POOL.repay(address(debtAsset), debtRepayAmount, debtRateMode, msg.sender);
+    IERC20(debtAsset).safeApprove(address(POOL), 0);
 
     {
       //transfer excess of debtAsset back to the user, if any
@@ -188,9 +188,9 @@ contract ParaSwapRepayAdapter is BaseParaSwapBuyAdapter, ReentrancyGuard {
     );
 
     // Repay debt. Approves for 0 first to comply with tokens that implement the anti frontrunning approval fix.
-    IERC20(debtAsset).safeApprove(address(POOL), 0);
     IERC20(debtAsset).safeApprove(address(POOL), debtRepayAmount);
     POOL.repay(address(debtAsset), debtRepayAmount, rateMode, initiator);
+    IERC20(debtAsset).safeApprove(address(POOL), 0);
 
     uint256 neededForFlashLoanRepay = amountSold.add(premium);
 


### PR DESCRIPTION
This PR applies two significant changes to the repay with collateral action:
- Resets the allowance from the adapter contract to the Augustus contract after Paraswap execution. This ensures no pending allowance is left.
- Transfers excess of assets after the swap to the user. This ensures that in case the buy is not completely "exact out", the excess will be transferred to the user rather than remaining within the contract.


This is a mirror PR of the https://github.com/aave/aave-v3-periphery/pull/193.