### PR TITLE
perf: dont use reserve data extended

### DIFF
--- a/src/periphery/contracts/static-a-token/ERC4626StataTokenUpgradeable.sol
+++ b/src/periphery/contracts/static-a-token/ERC4626StataTokenUpgradeable.sol
@@ -139,18 +139,19 @@ abstract contract ERC4626StataTokenUpgradeable is ERC4626Upgradeable, IERC4626St
 
   ///@inheritdoc IERC4626
   function maxRedeem(address owner) public view override returns (uint256) {
-    DataTypes.ReserveData memory reserveData = POOL.getReserveDataExtended(asset());
+    DataTypes.ReserveConfigurationMap memory reserveConfiguration = POOL.getConfiguration(asset());
 
     // if paused or inactive users cannot withdraw underlying
     if (
-      !ReserveConfiguration.getActive(reserveData.configuration) ||
-      ReserveConfiguration.getPaused(reserveData.configuration)
+      !ReserveConfiguration.getActive(reserveConfiguration) ||
+      ReserveConfiguration.getPaused(reserveConfiguration)
     ) {
       return 0;
     }
 
     // otherwise users can withdraw up to the available amount
-    uint256 underlyingTokenBalanceInShares = convertToShares(reserveData.virtualUnderlyingBalance);
+    uint128 virtualUnderlyingBalance = POOL.getVirtualUnderlyingBalance(asset());
+    uint256 underlyingTokenBalanceInShares = convertToShares(virtualUnderlyingBalance);
     uint256 cachedUserBalance = balanceOf(owner);
     return
       underlyingTokenBalanceInShares >= cachedUserBalance


### PR DESCRIPTION
```diff
- | maxRedeem                                                                                                               | 11059           | 11059   | 11059   | 11059   | 2       |
+ | maxRedeem                                                                                                               | 8305            | 8305    | 8305    | 8305    | 2       |
- | maxWithdraw                                                                                                             | 13705           | 13705   | 13705   | 13705   | 1       |
+ | maxWithdraw                                                                                                             | 10951           | 10951   | 10951   | 10951   | 1       |
```