### PR TITLE
feat: v3.2 pdp (protocol data provider) upgrade

### DIFF
--- a/certora/stata/harness/pool/SymbolicLendingPool.sol
+++ b/certora/stata/harness/pool/SymbolicLendingPool.sol
@@ -93,10 +93,7 @@ contract SymbolicLendingPool {
     return reserve.configuration;
   }
 
-  function getVirtualUnderlyingBalance(
-    address asset
-  ) external view virtual returns (uint128) {
+  function getVirtualUnderlyingBalance(address asset) external view virtual returns (uint128) {
     return reserve.virtualUnderlyingBalance;
   }
-
 }

--- a/src/contracts/instances/PoolInstance.sol
+++ b/src/contracts/instances/PoolInstance.sol
@@ -6,7 +6,7 @@ import {IPoolAddressesProvider} from '../interfaces/IPoolAddressesProvider.sol';
 import {Errors} from '../protocol/libraries/helpers/Errors.sol';
 
 contract PoolInstance is Pool {
-  uint256 public constant POOL_REVISION = 5;
+  uint256 public constant POOL_REVISION = 6;
 
   constructor(IPoolAddressesProvider provider) Pool(provider) {}
 

--- a/src/contracts/protocol/pool/Pool.sol
+++ b/src/contracts/protocol/pool/Pool.sol
@@ -452,7 +452,7 @@ abstract contract Pool is VersionedInitializable, PoolStorage, IPool {
     res.isolationModeTotalDebt = reserve.isolationModeTotalDebt;
     // This is a temporary workaround for integrations that are broken by Aave 3.2
     // While the new pool data provider is backward compatible, some integrations hard-code an old implementation
-    // To allow them to unlock the funds, the pool address provider is setting a stable debt token, so balanceOf() and totalSupply() will return zero instead of reverting
+    // To allow them to not have any infrastructural blocker, a mock must be configured in the Aave Pool Addresses Provider, returning zero on all required view methods, instead of reverting
     res.stableDebtTokenAddress = ADDRESSES_PROVIDER.getAddress(bytes32('MOCK_STABLE_DEBT'));
     return res;
   }

--- a/src/contracts/protocol/pool/Pool.sol
+++ b/src/contracts/protocol/pool/Pool.sol
@@ -450,6 +450,10 @@ abstract contract Pool is VersionedInitializable, PoolStorage, IPool {
     res.accruedToTreasury = reserve.accruedToTreasury;
     res.unbacked = reserve.unbacked;
     res.isolationModeTotalDebt = reserve.isolationModeTotalDebt;
+    // This is a temporary workaround for integrations that are broken by Aave 3.2
+    // While the new pool data provider is backward compatible, some integrations hard-code an old implementation
+    // To allow them to unlock the funds, the pool address provider is setting a stable debt token, so balanceOf() and totalSupply() will return zero instead of reverting
+    res.stableDebtTokenAddress = ADDRESSES_PROVIDER.getAddress(bytes32('MOCK_STABLE_DEBT'));
     return res;
   }
 


### PR DESCRIPTION
This pr allows returning a "MOCK_STABLE_DEBT" address in the position of `ReserveData.stableDebtToken` configurable via the pool address provider.

**Context**: On the Aave v3.2 upgrade, stable debt tokens were removed.
To maintain backward compatibility, fallbacks were added to the new `protocolDataProvider` which you obtain by fetching `getPoolDataProvider`. However, some integrations have opted to **hard-code** this mutable address of an immutable contract for gas optimizations.
This hard **hard-coded** address cannot be easily patched as it relies on things that no longer exist.
To provide an escape hatch, on pools with broken integrations, it's possible to return a non-zero address here, which will not revert for `totalSupply()` and `balanceOf()` calls.