### PR TITLE
ci: execute gas reports and coverage on each ci run

### DIFF
--- a/.github/workflows/comment.yml
+++ b/.github/workflows/comment.yml
@@ -1,4 +1,9 @@
-name: PR Comment
+# By calling this ci via `workflow_call` from another ci it has permissions to comment on prs from forks
+# This action expects the a artifact named `content` to be present in the workflow run
+# If the artifact contains a pr_number.txt, the action will comment on that pr. If not it comments on the commit.
+# The content of the messages composed by concatinating all *.txt files within content into a single file
+# If you want to enforce a specific order, you need to name the files in a way that sorts in the desired order
+name: Comment
 
 on:
   workflow_run:
@@ -6,69 +11,48 @@ on:
     types:
       - completed
 
-permissions:
-  actions: read
-  issues: write
-  checks: read
-  statuses: read
-  pull-requests: write
-
 jobs:
   comment:
     name: Comment Bot
     runs-on: ubuntu-latest
-    # workflow run triggers on all types of "completed" including "cancelled" and similar
-    # we want this action to only run on a success & failure though
-    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event.workflow_run.conclusion == 'failure' }}
     steps:
       - uses: actions/download-artifact@v4
         with:
-          name: pr_number
-          path: pr/
+          name: content
+          path: /tmp/content
           run-id: ${{ github.event.workflow_run.id }}
-          github-token: ${{ github.token }}
+          github-token: ${{ secrets.READ_ONLY_PAT }}
 
       - name: Read pr number
         id: get_pr_number
-        run: echo "pr_number=$(cat pr/pr_number.txt)" >> $GITHUB_OUTPUT
+        run: |
+          echo "pr_number=$(cat /tmp/content/pr_number.txt)" >> $GITHUB_OUTPUT
+          rm /tmp/content/pr_number.txt
 
-      - uses: actions/download-artifact@v4
-        with:
-          name: ${{ github.event.workflow_run.head_sha }}
-          path: tmp/
-          run-id: ${{ github.event.workflow_run.id }}
-          github-token: ${{ github.token }}
+      - name: Combine
+        id: combine
+        run: cat /tmp/content/*.txt > /tmp/all.txt
 
       - name: Find Comment
-        uses: peter-evans/find-comment@782f37b1a8a2b3e2eb9e86a994f0871e9dc146e3
+        uses: peter-evans/find-comment@v3
         id: fc
         if: ${{ steps.get_pr_number.outputs.pr_number != null }}
         with:
           issue-number: ${{ steps.get_pr_number.outputs.pr_number }}
           comment-author: "github-actions[bot]"
-          body-includes: Foundry report
 
       - name: Create or update pr comment
-        uses: peter-evans/create-or-update-comment@48bb05bd5554c378187694936d277d48652922e7
+        uses: peter-evans/create-or-update-comment@v4
         if: ${{ steps.get_pr_number.outputs.pr_number != null }}
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           issue-number: ${{ steps.get_pr_number.outputs.pr_number }}
-          body-file: tmp/template.md
+          body-file: /tmp/all.txt
           edit-mode: replace
 
-      - id: get-comment-body
-        if: ${{ steps.get_pr_number.outputs.pr_number == null }}
-        run: |
-          body="$(cat tmp/template.md)"
-          delimiter="$(openssl rand -hex 8)"
-          echo "body<<$delimiter" >> $GITHUB_OUTPUT
-          echo "$body" >> $GITHUB_OUTPUT
-          echo "$delimiter" >> $GITHUB_OUTPUT
-
       - name: Create or update commit comment
-        uses: peter-evans/commit-comment@ae7c3825ead23dab7a1ad8cd4df9617ab4bf0b37
+        uses: peter-evans/commit-comment@v3
         if: ${{ steps.get_pr_number.outputs.pr_number == null }}
         with:
           sha: ${{ github.event.workflow_run.head_sha }}
-          body: ${{ steps.get-comment-body.outputs.body }}
+          body-file: /tmp/all.txt

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
       - uses: actions/setup-node@0a44ba7841725637a19e28fa30b79a866c81b0a6
         with:
           node-version-file: .nvmrc
@@ -36,58 +37,43 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+
       - uses: actions/setup-node@0a44ba7841725637a19e28fa30b79a866c81b0a6
         with:
           node-version-file: .nvmrc
           cache: "npm"
 
-      - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@8f1998e9878d786675189ef566a2e4bf24869773
-        with:
-          version: nightly
-
       - name: Install node dependencies
         run: npm ci --prefer-offline --no-audit
 
-      - name: Run Forge build
-        run: |
-          forge --version | sed -r 's/\x1B\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g' | tee /tmp/foundry_version ; test ${PIPESTATUS[0]} -eq 0
-          forge cache ls
-          forge build | sed -r 's/\x1B\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g' | tee /tmp/foundry_build ; test ${PIPESTATUS[0]} -eq 0
-        id: build
+      - name: Run Foundry setup
+        uses: bgd-labs/github-workflows/.github/actions/foundry-setup@d738561b5afce35ca3752b28236c9dd68a3fa822
 
       - name: Run Forge tests
-        run: |
-          forge test -vv | sed -r 's/\x1B\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g' | tee /tmp/foundry_test
-          echo "testStatus=${PIPESTATUS[0]}" >> $GITHUB_ENV
-        id: test
+        uses: bgd-labs/github-workflows/.github/actions/foundry-test@d738561b5afce35ca3752b28236c9dd68a3fa822
 
-      - name: Create comment body
-        id: get-comment-body
-        run: |
-          printf "Foundry report\n\n" > /tmp/template.md
-          printf "\`\`\`shell\n$(cat /tmp/foundry_version)\n\`\`\`\n\n" >> /tmp/template.md
-          printf "<details><summary>Build log</summary>\n\n\`\`\`shell\n$(cat /tmp/foundry_build)\n\`\`\`\n</details>\n\n" >> /tmp/template.md
-          printf "<details><summary>Test ${{ env.testStatus == 0 && 'success :rainbow:' || 'error :finnadie::x:'}}</summary>\n\n\`\`\`shell\n$(cat /tmp/foundry_test)\n\`\`\`\n</details>\n\n" >> /tmp/template.md
+      - name: Run Gas report
+        uses: bgd-labs/github-workflows/.github/actions/foundry-gas-report@d738561b5afce35ca3752b28236c9dd68a3fa822
 
-      - uses: actions/upload-artifact@v4
-        with:
-          name: ${{ github.event.pull_request.head.sha || github.sha }}
-          path: /tmp/template.md
+      - name: Cleanup
+        # This test will currently fail on coverage due to the gas limit beaing breached with optimizer disabled
+        run: rm tests/deployments/DeploymentsGasLimits.t.sol
+
+      - name: Run Lcov report
+        uses: bgd-labs/github-workflows/.github/actions/foundry-lcov-report@d738561b5afce35ca3752b28236c9dd68a3fa822
 
       - name: Save PR number
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' || github.event_name == 'pull_request_target'
         env:
           PR_NUMBER: ${{ github.event.number }}
         run: |
           mkdir -p ./pr
-          echo $PR_NUMBER > ./pr/pr_number.txt
+          echo $PR_NUMBER > /tmp/content/pr_number.txt
 
       - uses: actions/upload-artifact@v4
-        if: github.event_name == 'pull_request'
         with:
-          name: pr_number
-          path: pr/pr_number.txt
+          name: content
+          path: /tmp/content
 
       # we let failing tests pass so we can log them in the comment, still we want the ci to fail
       - name: Post test


### PR DESCRIPTION
With the current ci one is a bit blind when it comes to things like coverage or gas implications of a certain change.
This upgraded ci workflow will store the current state of things in an artifact on main, so every upcoming pr can be diffed against it.