### PR TITLE
cleanup: remove obsolete remappings

### DIFF
--- a/certora/stata/conf/verifyDoubleClaim.conf
+++ b/certora/stata/conf/verifyDoubleClaim.conf
@@ -21,8 +21,6 @@
     "StataTokenV2Harness:_reward_A=DummyERC20_rewardToken"
   ],
   "packages": [
-//     "aave-v3-core/=certora/stata/munged/src/core",
-  //   "aave-v3-periphery/=certora/stata/munged/src/periphery",
      "solidity-utils/=certora/stata/munged/lib/solidity-utils/src",
      "forge-std/=certora/stata/munged/lib/forge-std/src",
      "openzeppelin-contracts-upgradeable/=certora/stata/munged/lib/solidity-utils/lib/openzeppelin-contracts-upgradeable",

--- a/certora/stata/conf/verifyERC4626.conf
+++ b/certora/stata/conf/verifyERC4626.conf
@@ -21,8 +21,6 @@
     "StataTokenV2Harness:_reward_A=DummyERC20_rewardToken"
   ],
   "packages": [
-//     "aave-v3-core/=certora/stata/munged/src/contracts",
-//     "aave-v3-periphery/=certora/stata/munged/src/contracts/extensions",
      "solidity-utils/=certora/stata/munged/lib/solidity-utils/src",
      "forge-std/=certora/stata/munged/lib/forge-std/src",
      "openzeppelin-contracts-upgradeable/=certora/stata/munged/lib/solidity-utils/lib/openzeppelin-contracts-upgradeable",

--- a/certora/stata/conf/verifyERC4626DepositSummarization.conf
+++ b/certora/stata/conf/verifyERC4626DepositSummarization.conf
@@ -21,8 +21,6 @@
     "StataTokenV2Harness:_reward_A=DummyERC20_rewardToken"
   ],
   "packages": [
-//     "aave-v3-core/=certora/stata/munged/src/core",
-//     "aave-v3-periphery/=certora/stata/munged/src/periphery",
      "solidity-utils/=certora/stata/munged/lib/solidity-utils/src",
      "forge-std/=certora/stata/munged/lib/forge-std/src",
      "openzeppelin-contracts-upgradeable/=certora/stata/munged/lib/solidity-utils/lib/openzeppelin-contracts-upgradeable",

--- a/certora/stata/conf/verifyERC4626Extended.conf
+++ b/certora/stata/conf/verifyERC4626Extended.conf
@@ -21,8 +21,6 @@
     "StataTokenV2Harness:_reward_A=DummyERC20_rewardToken"
   ],
   "packages": [
-//     "aave-v3-core/=certora/stata/munged/src/core",
- //    "aave-v3-periphery/=certora/stata/munged/src/periphery",
      "solidity-utils/=certora/stata/munged/lib/solidity-utils/src",
      "forge-std/=certora/stata/munged/lib/forge-std/src",
      "openzeppelin-contracts-upgradeable/=certora/stata/munged/lib/solidity-utils/lib/openzeppelin-contracts-upgradeable",

--- a/certora/stata/conf/verifyERC4626MintDepositSummarization.conf
+++ b/certora/stata/conf/verifyERC4626MintDepositSummarization.conf
@@ -21,8 +21,6 @@
     "StataTokenV2Harness:_reward_A=DummyERC20_rewardToken"
   ],
   "packages": [
-     //"aave-v3-core/=certora/stata/munged/src/core",
-     //"aave-v3-periphery/=certora/stata/munged/src/periphery",
      "solidity-utils/=certora/stata/munged/lib/solidity-utils/src",
      "forge-std/=certora/stata/munged/lib/forge-std/src",
      "openzeppelin-contracts-upgradeable/=certora/stata/munged/lib/solidity-utils/lib/openzeppelin-contracts-upgradeable",

--- a/certora/stata/conf/verifyStataToken.conf
+++ b/certora/stata/conf/verifyStataToken.conf
@@ -21,8 +21,6 @@
     "StataTokenV2Harness:_reward_A=DummyERC20_rewardToken"
   ],
   "packages": [
-//     "aave-v3-core/=certora/stata/munged/src/core",
-  //   "aave-v3-periphery/=certora/stata/munged/src/periphery",
      "solidity-utils/=certora/stata/munged/lib/solidity-utils/src",
      "forge-std/=certora/stata/munged/lib/forge-std/src",
      "openzeppelin-contracts-upgradeable/=certora/stata/munged/lib/solidity-utils/lib/openzeppelin-contracts-upgradeable",

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,5 +1,3 @@
-aave-v3-core/=src/core/
-aave-v3-periphery/=src/periphery/
 solidity-utils/=lib/solidity-utils/src/
 forge-std/=lib/forge-std/src/
 ds-test/=lib/forge-std/lib/ds-test/src/


### PR DESCRIPTION
When using aave-v3-origin as a dependency & running `forge remappings` misleading remappings are generated due to obsolete remappings being stuck here.