### PR TITLE
fix: add _initGuard for collector

### DIFF
--- a/src/contracts/treasury/Collector.sol
+++ b/src/contracts/treasury/Collector.sol
@@ -88,6 +88,7 @@ contract Collector is VersionedInitializable, ICollector, ReentrancyGuard {
       _nextStreamId = nextStreamId;
     }
 
+    _initGuard();
     _setFundsAdmin(fundsAdmin);
   }
 


### PR DESCRIPTION
Adds `_initGuard()` on `initialize()` of the collector so we can init the ReentrancyGuard `_status` variable with default empty value (i.e 1)