### PR TITLE
test: snapshot improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "1.0.0",
       "license": "BUSL1.1",
       "dependencies": {
-        "@bgd-labs/aave-cli": "^1.1.12",
-        "catapulta-verify": "^1.2.1"
+        "@bgd-labs/aave-cli": "^1.1.14",
+        "catapulta-verify": "^1.3.0"
       },
       "devDependencies": {
         "prettier": "^2.8.3",
@@ -32,9 +32,9 @@
       "integrity": "sha512-ttmk5qPrrZfEYY4vZ+UO/V7lYU5934ONN9kJmU44lCpB+fhVagmDLrBgLq44etQeaHZXHKggOHRA8mts4eN4Ug=="
     },
     "node_modules/@bgd-labs/aave-cli": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/@bgd-labs/aave-cli/-/aave-cli-1.1.12.tgz",
-      "integrity": "sha512-PuxWcdmNmNjVHP9hzZpJ6LYyM6MViJCQQ7U4yEPjiAGQ0mQ9aJIfAq5EpNds6r4OmmxufZ+Ely6f8QkIrDXDdA==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/@bgd-labs/aave-cli/-/aave-cli-1.1.14.tgz",
+      "integrity": "sha512-fQcH+DWhabmhCsC0vXB9X6U2nb9+vAEaoU9FGyPX5FEEnwDBsPDjtUHuoW2xMRuy+HwDK541e4yV6RX0GiUgcA==",
       "dependencies": {
         "@bgd-labs/aave-address-book": "^4.5.1",
         "@bgd-labs/aave-v3-governance-cache": "^1.0.8",
@@ -1012,12 +1012,9 @@
       }
     },
     "node_modules/catapulta-verify": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/catapulta-verify/-/catapulta-verify-1.2.1.tgz",
-      "integrity": "sha512-yXJ0/WV/3w6WLrVUoe2maEqPlGDyCwQ9oIk2vUiw+kfEG7zMlFzSQB8xf7sAo8kUKk/fwaMEn9AQrb84Ubae4Q==",
-      "dependencies": {
-        "@bgd-labs/rpc-env": "^2.0.1"
-      },
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/catapulta-verify/-/catapulta-verify-1.3.0.tgz",
+      "integrity": "sha512-naKOmR5poR1qWrKUW9BeLS58uQ8Pte3VU/tqveX7lfrA7jX3sLly050Ux8vkfFGfBXqI0sknslUrD+hCH/1jLg==",
       "bin": {
         "catapulta-verify": "out/index.mjs"
       }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "prettier-plugin-solidity": "^1.1.1"
   },
   "dependencies": {
-    "@bgd-labs/aave-cli": "^1.1.12",
-    "catapulta-verify": "^1.2.1"
+    "@bgd-labs/aave-cli": "^1.1.14",
+    "catapulta-verify": "^1.3.0"
   }
 }

--- a/tests/utils/ProtocolV3TestBase.sol
+++ b/tests/utils/ProtocolV3TestBase.sol
@@ -380,11 +380,12 @@ contract ProtocolV3TestBase is DiffUtils {
   ) internal view virtual returns (ReserveConfig memory) {
     ReserveConfig memory localConfig;
     DataTypes.ReserveConfigurationMap memory configuration = pool.getConfiguration(reserve);
+    DataTypes.ReserveDataLegacy memory reserveData = pool.getReserveData(reserve);
 
     localConfig.underlying = reserve;
-    localConfig.aToken = pool.getReserveAToken(reserve);
-    localConfig.variableDebtToken = pool.getReserveVariableDebtToken(reserve);
-    localConfig.interestRateStrategy = pool.getReserveData(reserve).interestRateStrategyAddress;
+    localConfig.aToken = reserveData.aTokenAddress;
+    localConfig.variableDebtToken = reserveData.variableDebtTokenAddress;
+    localConfig.interestRateStrategy = reserveData.interestRateStrategyAddress;
     (
       localConfig.ltv,
       localConfig.liquidationThreshold,

--- a/tests/utils/ProtocolV3TestBase.sol
+++ b/tests/utils/ProtocolV3TestBase.sol
@@ -105,7 +105,7 @@ struct ReserveConfig {
 }
 
 struct LocalVars {
-  IPoolDataProvider.TokenData[] reserves;
+  address[] reserves;
   ReserveConfig[] configs;
 }
 
@@ -137,10 +137,10 @@ contract ProtocolV3TestBase is DiffUtils {
     bool poolConfigs
   ) public virtual returns (ReserveConfig[] memory) {
     string memory path = string(abi.encodePacked('./reports/', reportName, '.json'));
-    // overwrite with empty json to later be extended
+    // overwrite with empty json to later be extended as foundry does not currently support adding new keys
     vm.writeFile(
       path,
-      '{ "eModes": {}, "reserves": {}, "strategies": {}, "poolConfiguration": {} }'
+      '{ "eModes": {}, "reserves": {}, "strategies": {}, "poolConfiguration": {}, "raw": {} }'
     );
     vm.serializeUint('root', 'chainId', block.chainid);
     ReserveConfig[] memory configs = _getReservesConfigs(pool);
@@ -280,21 +280,8 @@ contract ProtocolV3TestBase is DiffUtils {
       vm.serializeAddress(key, 'underlying', config.underlying);
       vm.serializeAddress(key, 'aToken', config.aToken);
       vm.serializeAddress(key, 'variableDebtToken', config.variableDebtToken);
-      vm.serializeAddress(
-        key,
-        'aTokenImpl',
-        ProxyHelpers.getInitializableAdminUpgradeabilityProxyImplementation(vm, config.aToken)
-      );
       vm.serializeString(key, 'aTokenSymbol', IERC20Detailed(config.aToken).symbol());
       vm.serializeString(key, 'aTokenName', IERC20Detailed(config.aToken).name());
-      vm.serializeAddress(
-        key,
-        'variableDebtTokenImpl',
-        ProxyHelpers.getInitializableAdminUpgradeabilityProxyImplementation(
-          vm,
-          config.variableDebtToken
-        )
-      );
       vm.serializeString(
         key,
         'variableDebtTokenSymbol',
@@ -361,22 +348,12 @@ contract ProtocolV3TestBase is DiffUtils {
     // pool configurator
     IPoolConfigurator configurator = IPoolConfigurator(addressesProvider.getPoolConfigurator());
     vm.serializeAddress(poolConfigKey, 'poolConfigurator', address(configurator));
-    vm.serializeAddress(
-      poolConfigKey,
-      'poolConfiguratorImpl',
-      ProxyHelpers.getInitializableAdminUpgradeabilityProxyImplementation(vm, address(configurator))
-    );
 
     // PoolDataProvider
     IPoolDataProvider pdp = IPoolDataProvider(addressesProvider.getPoolDataProvider());
     vm.serializeAddress(poolConfigKey, 'protocolDataProvider', address(pdp));
 
     // pool
-    vm.serializeAddress(
-      poolConfigKey,
-      'poolImpl',
-      ProxyHelpers.getInitializableAdminUpgradeabilityProxyImplementation(vm, address(pool))
-    );
     string memory content = vm.serializeAddress(poolConfigKey, 'pool', address(pool));
 
     string memory output = vm.serializeString('root', 'poolConfig', content);
@@ -384,53 +361,30 @@ contract ProtocolV3TestBase is DiffUtils {
   }
 
   function _getReservesConfigs(IPool pool) internal view virtual returns (ReserveConfig[] memory) {
-    IPoolAddressesProvider addressesProvider = IPoolAddressesProvider(pool.ADDRESSES_PROVIDER());
-    IPoolDataProvider poolDataProvider = IPoolDataProvider(addressesProvider.getPoolDataProvider());
     LocalVars memory vars;
 
-    vars.reserves = poolDataProvider.getAllReservesTokens();
+    vars.reserves = pool.getReservesList();
 
     vars.configs = new ReserveConfig[](vars.reserves.length);
 
     for (uint256 i = 0; i < vars.reserves.length; i++) {
-      vars.configs[i] = _getStructReserveConfig(pool, poolDataProvider, vars.reserves[i]);
+      vars.configs[i] = _getStructReserveConfig(pool, vars.reserves[i]);
     }
 
     return vars.configs;
   }
 
-  function _getStructReserveTokens(
-    IPoolDataProvider pdp,
-    address underlyingAddress
-  ) internal view virtual returns (ReserveTokens memory) {
-    ReserveTokens memory reserveTokens;
-    (reserveTokens.aToken, , reserveTokens.variableDebtToken) = pdp.getReserveTokensAddresses(
-      underlyingAddress
-    );
-
-    return reserveTokens;
-  }
-
   function _getStructReserveConfig(
     IPool pool,
-    IPoolDataProvider poolDataProvider,
-    IPoolDataProvider.TokenData memory reserve
+    address reserve
   ) internal view virtual returns (ReserveConfig memory) {
     ReserveConfig memory localConfig;
-    DataTypes.ReserveConfigurationMap memory configuration = pool.getConfiguration(
-      reserve.tokenAddress
-    );
+    DataTypes.ReserveConfigurationMap memory configuration = pool.getConfiguration(reserve);
 
-    localConfig.underlying = reserve.tokenAddress;
-    ReserveTokens memory reserveTokens = _getStructReserveTokens(
-      poolDataProvider,
-      reserve.tokenAddress
-    );
-    localConfig.aToken = reserveTokens.aToken;
-    localConfig.variableDebtToken = reserveTokens.variableDebtToken;
-    localConfig.interestRateStrategy = pool
-      .getReserveData(reserve.tokenAddress)
-      .interestRateStrategyAddress;
+    localConfig.underlying = reserve;
+    localConfig.aToken = pool.getReserveAToken(reserve);
+    localConfig.variableDebtToken = pool.getReserveVariableDebtToken(reserve);
+    localConfig.interestRateStrategy = pool.getReserveData(reserve).interestRateStrategyAddress;
     (
       localConfig.ltv,
       localConfig.liquidationThreshold,
@@ -444,7 +398,11 @@ contract ProtocolV3TestBase is DiffUtils {
       localConfig.borrowingEnabled,
       localConfig.isPaused
     ) = configuration.getFlags();
-    localConfig.symbol = reserve.symbol;
+    if (reserve == 0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2) {
+      localConfig.symbol = 'MKR';
+    } else {
+      localConfig.symbol = IERC20Detailed(reserve).symbol();
+    }
     localConfig.usageAsCollateralEnabled = localConfig.liquidationThreshold != 0;
     localConfig.isSiloed = configuration.getSiloedBorrowing();
     (localConfig.borrowCap, localConfig.supplyCap) = configuration.getCaps();
@@ -458,11 +416,9 @@ contract ProtocolV3TestBase is DiffUtils {
     localConfig.virtualAccActive = configuration.getIsVirtualAccActive();
 
     if (localConfig.virtualAccActive) {
-      localConfig.virtualBalance = pool.getVirtualUnderlyingBalance(reserve.tokenAddress);
+      localConfig.virtualBalance = pool.getVirtualUnderlyingBalance(reserve);
     }
-    localConfig.aTokenUnderlyingBalance = IERC20Detailed(reserve.tokenAddress).balanceOf(
-      localConfig.aToken
-    );
+    localConfig.aTokenUnderlyingBalance = IERC20Detailed(reserve).balanceOf(localConfig.aToken);
 
     return localConfig;
   }


### PR DESCRIPTION
Snapshotting implementations is unnecessary as with newer version of foundry one can easily record the storage diff. So removing this will reduce the rpc load in case a implementation does **not** change, while at the same time recording implementations that we currently don't record.