### PR TITLE
fix: disable initializers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "BUSL1.1",
       "dependencies": {
-        "@bgd-labs/aave-cli": "^1.1.14",
+        "@bgd-labs/aave-cli": "^1.1.17",
         "catapulta-verify": "^1.3.0"
       },
       "devDependencies": {
@@ -27,19 +27,19 @@
       "license": "Apache-2.0"
     },
     "node_modules/@bgd-labs/aave-address-book": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/@bgd-labs/aave-address-book/-/aave-address-book-4.5.1.tgz",
-      "integrity": "sha512-ttmk5qPrrZfEYY4vZ+UO/V7lYU5934ONN9kJmU44lCpB+fhVagmDLrBgLq44etQeaHZXHKggOHRA8mts4eN4Ug=="
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@bgd-labs/aave-address-book/-/aave-address-book-4.9.0.tgz",
+      "integrity": "sha512-abw6Z1p8Kt0DSlXXWs8kiiadONS49KgcOIn6WW7fSMzFRFZ3HYoRUt/hu6uNfEmbQ5cO9Qe+leAp2O+o9oovWw=="
     },
     "node_modules/@bgd-labs/aave-cli": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/@bgd-labs/aave-cli/-/aave-cli-1.1.14.tgz",
-      "integrity": "sha512-fQcH+DWhabmhCsC0vXB9X6U2nb9+vAEaoU9FGyPX5FEEnwDBsPDjtUHuoW2xMRuy+HwDK541e4yV6RX0GiUgcA==",
+      "version": "1.1.17",
+      "resolved": "https://registry.npmjs.org/@bgd-labs/aave-cli/-/aave-cli-1.1.17.tgz",
+      "integrity": "sha512-FfBiH2AAweXduRIBTF+jQYp8Z2bRxtKNNZQCfy36i3gMkCtB2mmNikWYf3SK1vNb0mkXl2Rf0/ECZuaKWwsN+Q==",
       "dependencies": {
-        "@bgd-labs/aave-address-book": "^4.5.1",
-        "@bgd-labs/aave-v3-governance-cache": "^1.0.8",
-        "@bgd-labs/js-utils": "^1.4.6",
-        "@bgd-labs/rpc-env": "^2.1.1",
+        "@bgd-labs/aave-address-book": "^4.9.0",
+        "@bgd-labs/aave-v3-governance-cache": "^1.0.10",
+        "@bgd-labs/js-utils": "^1.4.7",
+        "@bgd-labs/rpc-env": "^2.3.2",
         "@commander-js/extra-typings": "^12.1.0",
         "@inquirer/prompts": "^7.1.0",
         "blockstore-core": "^5.0.2",
@@ -51,7 +51,7 @@
         "gray-matter": "^4.0.3",
         "ipfs-unixfs-importer": "^15.3.1",
         "json-bigint": "^1.0.0",
-        "viem": "^2.21.48",
+        "viem": "^2.22.21",
         "zod": "^3.23.8"
       },
       "bin": {
@@ -59,19 +59,23 @@
       }
     },
     "node_modules/@bgd-labs/aave-v3-governance-cache": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@bgd-labs/aave-v3-governance-cache/-/aave-v3-governance-cache-1.0.8.tgz",
-      "integrity": "sha512-niaJafgxLQcuzZ13Wo1rO5tJ8f5pE5AdWs+5/PoHMrk5Z+bm5kE59oHbIO2xpg1pCQ7IZmsxXEIIlC2c0+v/Jg==",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@bgd-labs/aave-v3-governance-cache/-/aave-v3-governance-cache-1.0.10.tgz",
+      "integrity": "sha512-Lxduv9mvtCjeEQ7BEjO2XI1jRewQxmlpXI9vWnA/gj+vTcEOWuyrcFb+E2a7zGKcnD0j9wvTqXVJ+JSF0gM2qw==",
+      "dependencies": {
+        "@bgd-labs/rpc-env": "^2.3.1"
+      },
       "peerDependencies": {
-        "@bgd-labs/aave-address-book": "^4.0.1-02c70ec5f8a433b38372b81d27ed44b79aa52f65.0",
-        "viem": "^2.9.20"
+        "@bgd-labs/aave-address-book": "^4.8.1",
+        "viem": "^2.22.16"
       }
     },
     "node_modules/@bgd-labs/js-utils": {
-      "version": "1.4.6",
-      "resolved": "https://registry.npmjs.org/@bgd-labs/js-utils/-/js-utils-1.4.6.tgz",
-      "integrity": "sha512-0IA3fbHo/PJvtBPZ0q0zepsmsbZRAujchdd7GVsKJcJQ2xQulWYUZ9IeV+TTroR9wukKBgf6teYxEjCx0FVfuA==",
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/@bgd-labs/js-utils/-/js-utils-1.4.7.tgz",
+      "integrity": "sha512-rv8VZkNQlt71LPqveo1o/LMilq6XRS3gTJeDaoDCUtzFpv16S9PqZe92uoYLatUhhSvBEXKMmjnOoW/WbMsdVQ==",
       "dependencies": {
+        "@bgd-labs/rpc-env": "^2.3.0",
         "@supercharge/promise-pool": "^3.1.1",
         "bs58": "^5.0.0",
         "gray-matter": "^4.0.3",
@@ -85,9 +89,9 @@
       }
     },
     "node_modules/@bgd-labs/rpc-env": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@bgd-labs/rpc-env/-/rpc-env-2.1.1.tgz",
-      "integrity": "sha512-m3WAyez8ySgaNNrDOf4MCvtDQAF67Y/HTfUirW0D4G9rFvpqiWxU7+NVfGaI3RPd5DoUcZFwGDxnXUPibNL2CQ==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@bgd-labs/rpc-env/-/rpc-env-2.3.2.tgz",
+      "integrity": "sha512-yTuQjf9oHCrPDPGHUDUUU0M7QWZTrc271cG5ei9kZJjsqweMYvvNweoFBsmP//2X4r8foCQPL+HZ0dQV54OAsQ==",
       "bin": {
         "rpc-env": "dist/cli.js"
       }
@@ -777,11 +781,11 @@
       }
     },
     "node_modules/@noble/curves": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.6.0.tgz",
-      "integrity": "sha512-TlaHRXDehJuRNR9TfZDNQ45mMEd5dwUwmicsafcIX4SsNiqnCHKjE/1alYPd/lDRVhxdhUAlv8uEhMCI5zjIJQ==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.8.1.tgz",
+      "integrity": "sha512-warwspo+UYUPep0Q+vtdVB4Ugn8GGQj8iyB3gnRWsztmUHTI3S1nhdiWNsPUGL0vud7JlRRk1XEu7Lq1KGTnMQ==",
       "dependencies": {
-        "@noble/hashes": "1.5.0"
+        "@noble/hashes": "1.7.1"
       },
       "engines": {
         "node": "^14.21.3 || >=16"
@@ -791,9 +795,9 @@
       }
     },
     "node_modules/@noble/hashes": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.5.0.tgz",
-      "integrity": "sha512-1j6kQFb7QRru7eKN3ZDvRcP13rugwdxZqCjbiAVZfIJwgj2A65UmT4TgARXGlXgnRkORLTDTrO19ZErt7+QXgA==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.1.tgz",
+      "integrity": "sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ==",
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -802,33 +806,33 @@
       }
     },
     "node_modules/@scure/base": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.9.tgz",
-      "integrity": "sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.4.tgz",
+      "integrity": "sha512-5Yy9czTO47mqz+/J8GM6GIId4umdCk1wc1q8rKERQulIoc8VP9pzDcghv10Tl2E7R96ZUx/PhND3ESYUQX8NuQ==",
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@scure/bip32": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.5.0.tgz",
-      "integrity": "sha512-8EnFYkqEQdnkuGBVpCzKxyIwDCBLDVj3oiX0EKUFre/tOjL/Hqba1D6n/8RcmaQy4f95qQFrO2A8Sr6ybh4NRw==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.6.2.tgz",
+      "integrity": "sha512-t96EPDMbtGgtb7onKKqxRLfE5g05k7uHnHRM2xdE6BP/ZmxaLtPek4J4KfVn/90IQNrU1IOAqMgiDtUdtbe3nw==",
       "dependencies": {
-        "@noble/curves": "~1.6.0",
-        "@noble/hashes": "~1.5.0",
-        "@scure/base": "~1.1.7"
+        "@noble/curves": "~1.8.1",
+        "@noble/hashes": "~1.7.1",
+        "@scure/base": "~1.2.2"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@scure/bip39": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.4.0.tgz",
-      "integrity": "sha512-BEEm6p8IueV/ZTfQLp/0vhw4NPnT9oWf5+28nvmeUICjP99f4vr2d+qc7AVGDDtwRep6ifR43Yed9ERVmiITzw==",
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.5.4.tgz",
+      "integrity": "sha512-TFM4ni0vKvCfBpohoh+/lY05i9gRbSwXWngAsF4CABQxoaOHijxuaZ2R6cStDQ5CHtHO9aGJTr4ksVJASRRyMA==",
       "dependencies": {
-        "@noble/hashes": "~1.5.0",
-        "@scure/base": "~1.1.8"
+        "@noble/hashes": "~1.7.1",
+        "@scure/base": "~1.2.4"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -864,9 +868,9 @@
       }
     },
     "node_modules/abitype": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.0.6.tgz",
-      "integrity": "sha512-MMSqYh4+C/aVqI2RQaWqbvI4Kxo5cQV40WQ4QFtDnNzCkqChm8MuENhElmynZlO0qUy/ObkEUaXtKqYnx1Kp3A==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.0.8.tgz",
+      "integrity": "sha512-ZeiI6h3GnW06uYDLx0etQtX/p8E24UaHHBj57RSjK7YBFe7iuVn07EDpOeP451D06sF27VOz9JJPlIKJmXgkEg==",
       "funding": {
         "url": "https://github.com/sponsors/wevm"
       },
@@ -1216,9 +1220,9 @@
       }
     },
     "node_modules/get-tsconfig": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.8.1.tgz",
-      "integrity": "sha512-k9PN+cFBmaLWtVz29SkUoqU5O0slLuHJXt/2P+tMVFT+phsSGXGkp9t3rQIqdz0e+06EHNGs3oM6ZX1s2zHxRg==",
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.10.0.tgz",
+      "integrity": "sha512-kGzZ3LWWQcGIAmg6iWvXn0ei6WDtV26wzHRMwDSzmAbcXrTEXxHy6IehI6/4eT6VRKyMP1eF1VqwrVUmE/LR7A==",
       "dependencies": {
         "resolve-pkg-maps": "^1.0.0"
       },
@@ -1527,9 +1531,9 @@
       }
     },
     "node_modules/ox": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/ox/-/ox-0.1.2.tgz",
-      "integrity": "sha512-ak/8K0Rtphg9vnRJlbOdaX9R7cmxD2MiSthjWGaQdMk3D7hrAlDoM+6Lxn7hN52Za3vrXfZ7enfke/5WjolDww==",
+      "version": "0.6.7",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.6.7.tgz",
+      "integrity": "sha512-17Gk/eFsFRAZ80p5eKqv89a57uXjd3NgIf1CaXojATPBuujVc/fQSVhBeAU9JCRB+k7J50WQAyWTxK19T9GgbA==",
       "funding": [
         {
           "type": "github",
@@ -1837,19 +1841,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/typescript": {
-      "version": "5.4.4",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
     "node_modules/uint8-varint": {
       "version": "2.0.4",
       "license": "Apache-2.0 OR MIT",
@@ -1882,9 +1873,9 @@
       "license": "MIT"
     },
     "node_modules/viem": {
-      "version": "2.21.48",
-      "resolved": "https://registry.npmjs.org/viem/-/viem-2.21.48.tgz",
-      "integrity": "sha512-/hBHyG1gdIIuiQv0z9YmzXl5eWJa0UCZGwkeuQzH2Bmg6FIEwZeEcxgiytXZydip+p2wMBFa1jdr7o5O1+mrIg==",
+      "version": "2.22.21",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.22.21.tgz",
+      "integrity": "sha512-CujapStF+F3VP+bKBQOGFk5YHyJKZOY2TGvD1e04CAm8VrtLo3sfTydYW2Rri6LMktqp6ilGB9GvSiZczxvOBQ==",
       "funding": [
         {
           "type": "github",
@@ -1892,14 +1883,13 @@
         }
       ],
       "dependencies": {
-        "@noble/curves": "1.6.0",
-        "@noble/hashes": "1.5.0",
-        "@scure/bip32": "1.5.0",
-        "@scure/bip39": "1.4.0",
-        "abitype": "1.0.6",
+        "@noble/curves": "1.8.1",
+        "@noble/hashes": "1.7.1",
+        "@scure/bip32": "1.6.2",
+        "@scure/bip39": "1.5.4",
+        "abitype": "1.0.8",
         "isows": "1.0.6",
-        "ox": "0.1.2",
-        "webauthn-p256": "0.0.10",
+        "ox": "0.6.7",
         "ws": "8.18.0"
       },
       "peerDependencies": {
@@ -1937,21 +1927,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
-    },
-    "node_modules/webauthn-p256": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/webauthn-p256/-/webauthn-p256-0.0.10.tgz",
-      "integrity": "sha512-EeYD+gmIT80YkSIDb2iWq0lq2zbHo1CxHlQTeJ+KkCILWpVy3zASH3ByD4bopzfk0uCwXxLqKGLqp2W4O28VFA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/wevm"
-        }
-      ],
-      "dependencies": {
-        "@noble/curves": "^1.4.0",
-        "@noble/hashes": "^1.4.0"
       }
     },
     "node_modules/webidl-conversions": {
@@ -2016,8 +1991,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.23.8",
-      "license": "MIT",
+      "version": "3.24.1",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.1.tgz",
+      "integrity": "sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A==",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "prettier-plugin-solidity": "^1.1.1"
   },
   "dependencies": {
-    "@bgd-labs/aave-cli": "^1.1.14",
+    "@bgd-labs/aave-cli": "^1.1.17",
     "catapulta-verify": "^1.3.0"
   }
 }

--- a/src/contracts/extensions/stata-token/StataTokenFactory.sol
+++ b/src/contracts/extensions/stata-token/StataTokenFactory.sol
@@ -39,6 +39,7 @@ contract StataTokenFactory is Initializable, IStataTokenFactory {
     ITransparentProxyFactory transparentProxyFactory,
     address stataTokenImpl
   ) {
+    _disableInitializers();
     POOL = pool;
     INITIAL_OWNER = initialOwner;
     TRANSPARENT_PROXY_FACTORY = transparentProxyFactory;

--- a/tests/extensions/stata-token/TestBase.sol
+++ b/tests/extensions/stata-token/TestBase.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.10;
 
+import {Initializable} from 'openzeppelin-contracts-upgradeable/contracts/proxy/utils/Initializable.sol';
 import {IERC20Metadata, IERC20} from 'openzeppelin-contracts/contracts/token/ERC20/extensions/IERC20Metadata.sol';
 import {TransparentUpgradeableProxy} from 'openzeppelin-contracts/contracts/proxy/transparent/TransparentUpgradeableProxy.sol';
 import {ITransparentProxyFactory} from 'solidity-utils/contracts/transparent-proxy/interfaces/ITransparentProxyFactory.sol';
@@ -57,6 +58,8 @@ abstract contract BaseTest is TestnetProcedures {
     proxyFactory = ITransparentProxyFactory(report.transparentProxyFactory);
 
     factory = StataTokenFactory(report.staticATokenFactoryProxy);
+    vm.expectRevert(Initializable.InvalidInitialization.selector);
+    StataTokenFactory(report.staticATokenFactoryImplementation).initialize();
     factory.createStataTokens(contracts.poolProxy.getReservesList());
 
     stataTokenV2 = StataTokenV2(factory.getStataToken(underlying));

--- a/tests/utils/DiffUtils.sol
+++ b/tests/utils/DiffUtils.sol
@@ -22,7 +22,7 @@ contract DiffUtils is Test {
 
     string[] memory inputs = new string[](7);
     inputs[0] = 'npx';
-    inputs[1] = '@bgd-labs/aave-cli@^1.1.12';
+    inputs[1] = '@bgd-labs/aave-cli@^1.1.17';
     inputs[2] = 'diff-snapshots';
     inputs[3] = beforePath;
     inputs[4] = afterPath;


### PR DESCRIPTION
In https://github.com/aave-dao/aave-v3-origin/commit/7d706f00fa0c25f747c75284e8724dd927bbe42a we upgraded the tooling, but did not consider that the previous version of Initializable had a custom constructor that disabled initializers.

As we no longer rely on the custom version we need to apply the change on the initializer.
The Factory was the only contract that relied on this behavior.