### PR TITLE
fix: initialize funds admin on collector

### DIFF
--- a/src/contracts/treasury/Collector.sol
+++ b/src/contracts/treasury/Collector.sol
@@ -96,6 +96,7 @@ contract Collector is AccessControlUpgradeable, ReentrancyGuardUpgradeable, ICol
     __AccessControl_init();
     __ReentrancyGuard_init();
     _grantRole(DEFAULT_ADMIN_ROLE, admin);
+    _grantRole(FUNDS_ADMIN_ROLE, admin);
     if (nextStreamId != 0) {
       _nextStreamId = nextStreamId;
     }


### PR DESCRIPTION
Currently we only initialize the `DEFAULT_ADMIN` role on the collector, but it is reasonable to also initialize the `FUNDS_ADMIN` on the collectors initialize itself.