### PR TITLE
fix: checkout commit when submitting lcov to codecov

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,9 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+
       - uses: actions/download-artifact@v4
         with:
           name: lcov-report


### PR DESCRIPTION
Codecov requires the git to be initialized as otherwise apparently it has problems to identify which artifact belongs to what.
This pr fixes this by checking out the repo on the codecov flow.