### PR TITLE
[Fix] Add zero address validation for onBehalfOf in supply()

### DIFF
--- a/src/contracts/protocol/pool/Pool.sol
+++ b/src/contracts/protocol/pool/Pool.sol
@@ -148,6 +148,7 @@ abstract contract Pool is VersionedInitializable, PoolStorage, IPool {
     address onBehalfOf,
     uint16 referralCode
   ) public virtual override {
+    require(onBehalfOf != address(0), Errors.ZERO_ADDRESS_NOT_VALID);
     SupplyLogic.executeSupply(
       _reserves,
       _reservesList,


### PR DESCRIPTION
### Summary
This PR adds a validation check to ensure the `onBehalfOf` address in the `supply()` function is not the zero address.

### Reasoning
Passing the zero address as `onBehalfOf` could cause undefined behavior or unintended token assignment.  
Adding this check prevents potential misuse or loss of funds.

### Code Location
File: `src/contracts/protocol/pool/Pool.sol`  
Function: `supply(address asset, uint256 amount, address onBehalfOf, uint16 referralCode)`

### Fix
```solidity
require(onBehalfOf != address(0), Errors.ZERO_ADDRESS_NOT_VALID);
