### PR TITLE
Fixed edge case in the LiquidationDataProvider helper contract

### DIFF
--- a/src/contracts/helpers/LiquidationDataProvider.sol
+++ b/src/contracts/helpers/LiquidationDataProvider.sol
@@ -175,8 +175,11 @@ contract LiquidationDataProvider is ILiquidationDataProvider {
     );
 
     if (
-      liquidationInfo.maxDebtToLiquidate != 0 &&
-      liquidationInfo.maxDebtToLiquidate == liquidationInfo.debtInfo.debtBalance
+      (liquidationInfo.maxDebtToLiquidate != 0 &&
+        liquidationInfo.maxDebtToLiquidate == liquidationInfo.debtInfo.debtBalance) ||
+      (liquidationInfo.maxCollateralToLiquidate != 0 &&
+        liquidationInfo.maxCollateralToLiquidate ==
+        liquidationInfo.collateralInfo.collateralBalance)
     ) {
       liquidationInfo.amountToPassToLiquidationCall = type(uint256).max;
     } else {


### PR DESCRIPTION
The `LiquidationDataProvider` helper contract returns how much debt and collateral can be liquidated for a borrower. The return data should be passed to a liquidation call.

There existed two edge cases when this contract returns data, with which the `Pool` contract returns an error.

Example:
1. A borrower has `X` debt and `Y` collateral
2. Also, we can liquidate the whole `X` amount of debt from the borrower, but he doesn't have enough collateral. In this case, we can only liquidate `N` amount of debt (`N < X`) and `Y` amount of collateral.

For this example, we have two bad edge cases:
1. When we pass `N` amount of debt to be liquidated, the contract calculates the amount of collateral that will be liquidated. Sometimes this amount equals `M`, where `M < Y`, and we have some leftovers in the collateral. This happens because of an integer division and a `+-1` error. And these leftovers can be lower than the allowed threshold of leftovers (`1000$`), and because of that, a liquidation call reverts.
2. When we call the `LiquidationDataProvider` helper contract not in the same block as when we make a liquidation call, we may also face an error. This can happen because some time passed and a borrower now has a bigger amount of the collateral because he has some interest. And because of that, after a liquidation (`N` amount of debt and `Y` amount of collateral) there will be some leftovers in collateral token,s and those leftovers can be lower than the allowed threshold of leftovers (`1000$`), and because of that, a liquidation call reverts.

Solution:
Now, if a borrower has all his collateral balance liquidatable, the `LiquidationDataProvider` helper contract returns that we can liquidate the whole debt balance of the borrower. The `Pool` contract in this case will calculate itself how much debt and collateral will be liquidatable.