### PR TITLE
Add missing natspec for depositToAave parameter

### DIFF
--- a/src/contracts/extensions/stata-token/interfaces/IERC4626StataToken.sol
+++ b/src/contracts/extensions/stata-token/interfaces/IERC4626StataToken.sol
@@ -54,6 +54,7 @@ interface IERC4626StataToken {
    * @param receiver The address that will receive the static aTokens
    * @param deadline Must be a timestamp in the future
    * @param sig A `secp256k1` signature params from `msgSender()`
+   * @param depositToAave Whether to deposit the underlying asset (true) or aToken (false)
    * @return uint256 The amount of StaticAToken minted, static balance
    **/
   function depositWithPermit(


### PR DESCRIPTION
Add missing @param documentation for the depositToAave boolean parameter in IERC4626StataToken::depositWithPermit() function.

Fixes #83