### PR TITLE
Fix extra space in IPool.sol NatSpec documentation

### DIFF
--- a/src/contracts/interfaces/IPool.sol
+++ b/src/contracts/interfaces/IPool.sol
@@ -373,7 +373,7 @@ interface IPool {
    *   0 -> Don't open any debt, just revert if funds can't be transferred from the receiver
    *   1 -> Deprecated on v3.2.0
    *   2 -> Open debt at variable rate for the value of the amount flash-borrowed to the `onBehalfOf` address
-   * @param onBehalfOf The address  that will receive the debt in the case of using 2 on `modes`
+   * @param onBehalfOf The address that will receive the debt in the case of using 2 on `modes`
    * @param params Variadic packed params to pass to the receiver as extra information
    * @param referralCode The code used to register the integrator originating the operation, for potential rewards.
    *   0 if the action is executed directly by the user, without any middle-man


### PR DESCRIPTION
## Summary
- Fix typo in IPool.sol where there was a double space in the NatSpec documentation for the `onBehalfOf` parameter in the `flashLoan` function (line 376)

## Test plan
- No functional changes, documentation fix only