### PR TITLE
Fix duplicated 'the' in PoolAddressesProvider.sol

### DIFF
--- a/src/contracts/protocol/configuration/PoolAddressesProvider.sol
+++ b/src/contracts/protocol/configuration/PoolAddressesProvider.sol
@@ -191,7 +191,7 @@ contract PoolAddressesProvider is Ownable, IPoolAddressesProvider {
   }
 
   /**
-   * @notice Returns the the implementation contract of the proxy contract by its identifier.
+   * @notice Returns the implementation contract of the proxy contract by its identifier.
    * @dev It returns ZERO if there is no registered address with the given id
    * @dev It reverts if the registered address with the given id is not `InitializableImmutableAdminUpgradeabilityProxy`
    * @param id The id


### PR DESCRIPTION
## Summary
- Fix typo in PoolAddressesProvider.sol where "the" was duplicated in the NatSpec documentation:
  - Line 194: `Returns the the implementation contract` -> `Returns the implementation contract`

## Test plan
- No functional changes, documentation fix only