### PR TITLE
docs: document depositWithPermit depositToAave

### DIFF
--- a/src/contracts/extensions/stata-token/interfaces/IERC4626StataToken.sol
+++ b/src/contracts/extensions/stata-token/interfaces/IERC4626StataToken.sol
@@ -54,6 +54,7 @@ interface IERC4626StataToken {
    * @param receiver The address that will receive the static aTokens
    * @param deadline Must be a timestamp in the future
    * @param sig A `secp256k1` signature params from `msgSender()`
+   * @param depositToAave True to deposit underlying into Aave, false to deposit aTokens directly
    * @return uint256 The amount of StaticAToken minted, static balance
    **/
   function depositWithPermit(


### PR DESCRIPTION
## Summary
- document the `depositToAave` parameter on `IERC4626StataToken.depositWithPermit`
- clarify the underlying-vs-aToken deposit mode exposed by the boolean

Closes #83.

## Tests
- `git diff --check`

Note: this is a docs-only NatSpec change. I used sparse checkout because the repository currently has Windows checkout issues around reserved `aux` paths (tracked in #106), so I did not run the full test suite locally.