### PR TITLE
certora: fix remaining solvency liquidationCall timeouts

### DIFF
--- a/.github/workflows/certora-ATokenWithDelegation.yml
+++ b/.github/workflows/certora-ATokenWithDelegation.yml
@@ -56,5 +56,6 @@ jobs:
           job-name: "Certora Prover Run"
           certora-key: ${{ secrets.CERTORAKEY }}
           install-java: true
+          auto-rerun-timeouts: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/certora-basic.yml
+++ b/.github/workflows/certora-basic.yml
@@ -64,6 +64,7 @@ jobs:
           job-name: "Certora Prover Run"
           certora-key: ${{ secrets.CERTORAKEY }}
           install-java: true
+          auto-rerun-timeouts: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 # Put back the following rule after ticket 8889 is closed

--- a/.github/workflows/certora-math-calculations.yml
+++ b/.github/workflows/certora-math-calculations.yml
@@ -51,6 +51,7 @@ jobs:
           job-name: "Certora Prover Run"
           certora-key: ${{ secrets.CERTORAKEY }}
           install-java: true
+          auto-rerun-timeouts: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 # Put back the following rule after ticket 8889 is closed

--- a/.github/workflows/certora-solvency.yml
+++ b/.github/workflows/certora-solvency.yml
@@ -71,6 +71,7 @@ jobs:
           job-name: "Certora Prover Run"
           certora-key: ${{ secrets.CERTORAKEY }}
           install-java: true
+          auto-rerun-timeouts: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 # Put back the following rule after ticket 8889 is closed

--- a/.github/workflows/certora-stata.yml
+++ b/.github/workflows/certora-stata.yml
@@ -72,5 +72,6 @@ jobs:
           job-name: "Certora Prover Run"
           certora-key: ${{ secrets.CERTORAKEY }}
           install-java: true
+          auto-rerun-timeouts: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/certora/solvency/confs/solvency/liquidationCall/burnBadDebt-assetINloop.conf
+++ b/certora/solvency/confs/solvency/liquidationCall/burnBadDebt-assetINloop.conf
@@ -11,6 +11,9 @@
 	"optimistic_loop": true,
 	"process": "emv",
 //	"prover_args": [" -split false"	],
+	// Without twostage destructive optimizations solvency__burnBadDebt does not
+	// finish: the INTR2/INTR1 totSUP-debt assert alone exhausts smt_timeout.
+	"prover_args": [" -destructiveOptimizations twostage"],
         "server": "prover",               
 	"smt_timeout": "6000",
 	"solc": "solc8.27",

--- a/certora/solvency/confs/solvency/liquidationCall/main-COLasset.conf
+++ b/certora/solvency/confs/solvency/liquidationCall/main-COLasset.conf
@@ -9,6 +9,12 @@
   "optimistic_loop": true,
   "process": "emv",
 //  "prover_args": [" -split false"	],
+  // Same solver portfolio as main-COLasset-totSUP0: racing z3 seeds keeps
+  // solvency__liquidationCall_COLasset well clear of smt_timeout instead of
+  // finishing just under it.
+  "prover_args": [
+		"  -destructiveOptimizations twostage -s [z3:def{randomSeed=1},z3:def{randomSeed=2},z3:def{randomSeed=3},z3:def{randomSeed=4},z3:def{randomSeed=5},z3:def{randomSeed=6},z3:def{randomSeed=7},z3:def{randomSeed=8},z3:def{randomSeed=9},z3:def{randomSeed=10}]"
+	],
   "server": "prover",               
   "smt_timeout": "8000",
   "solc": "solc8.27",


### PR DESCRIPTION
Follow-up to #185, targeting `nurit/fixSanity` so it can be merged into that branch.

#185 fixes the vacuity failures in `certora-solvency` (the 6 jobs that were reporting `rule_not_vacuous` / "rule contains only reverting paths" on `main`). What remains red on the branch is a single **timeout**, plus one conf that passes with no margin. This PR addresses both, and adds a safety net for future timeouts.

## 1. `burnBadDebt-assetINloop.conf` — the actual failing job

On `a0eeb1f9` this conf runs **6325s and times out**: rule `solvency__burnBadDebt` plus its `Assert_INTR2_totSUP_debt__INTR1_totSUP_debt__AMOUNT` assert (`burnBadDebt-assetINloop.spec:76`) exhaust `smt_timeout`. It is the only reason the `certora-solvency` check is failing — the other 21 configs pass.

Enabling twostage destructive optimizations settles it:

| | duration | verdict |
|---|---|---|
| before | 6325s | 2 rules TIMEOUT |
| after | **483s** | 39 verified, 0 timeouts |

## 2. `main-COLasset.conf` — hardening, not a current failure

This conf currently *passes*, so it is not what makes the check red. But it takes ~1600s, and it did time out earlier on this same branch (a solver portfolio was run against it on 10 Jun). Its sibling `main-COLasset-totSUP0.conf` already carries a racing-z3-seed portfolio in `prover_args`; this one carried none. Giving it the same setting:

| | duration | verdict |
|---|---|---|
| before | 1600s | 68 verified (little margin) |
| after | **887s** | 68 verified |

Note this is a solver race, so its wall time will vary between runs; the point is the margin, not the exact number.

## 3. `auto-rerun-timeouts: true`

The action revision already pinned by #185 supports `auto-rerun-timeouts`, but none of the workflows opt in. With it enabled, a timed-out leaf is automatically retried against a portfolio of prover configurations server-side instead of failing the check outright. Enabled on all five certora workflows.

## How the settings were chosen

Both configs were run through a portfolio of ~11 prover configurations. The settings kept here are the ones that verified under **both** `certora-cli` 7.31.0 (the version these workflows pin) and 8.18.0, rather than a single lucky win:

| conf | setting | 7.31.0 | 8.18.0 |
|---|---|---|---|
| `burnBadDebt-assetINloop` | `-destructiveOptimizations twostage` | 514s | 411s |
| `main-COLasset` | `twostage` + z3 seeds 1-10 | 955s | 876s |

The `burnBadDebt` fix is deliberately the minimal one — plain `twostage`, no extra split/depth tuning — since that alone was sufficient. Configurations relying on underapproximation were rejected despite good times, as they return errored rules and are unsound to bake into CI.

The numbers in the tables above are from running the edited configs from this branch, not from a reduced repro.

`cli-version` is intentionally left at `7.31.0`. Both settings verify on it, so this PR carries no prover-version change for the other configs. 8.18.0 was consistently the faster of the two here, so bumping it looks worthwhile, but belongs in its own PR where any regression is attributable.
